### PR TITLE
fix #95: Sort proposal history events in descending order by date

### DIFF
--- a/src/stores/DaoStore.ts
+++ b/src/stores/DaoStore.ts
@@ -816,7 +816,7 @@ export default class DaoStore {
     history = _.orderBy(
       history,
       ['event.timestamp', 'event.logIndex'],
-      ['asc', 'asc']
+      ['desc', 'asc']
     );
 
     return {
@@ -826,7 +826,7 @@ export default class DaoStore {
       redeems: proposalEvents.redeems,
       redeemsRep: proposalEvents.redeemsRep,
       redeemsDaoBounty: proposalEvents.redeemsDaoBounty,
-      history: history,
+      history,
     };
   }
 


### PR DESCRIPTION
**Fix** https://github.com/DXgovernance/dxvote/issues/95

**Description**
Show proposal history events in descending order by date (new ones at the top)