### PR TITLE
Show proposals without connecting to a wallet.

### DIFF
--- a/src/PageRouter.tsx
+++ b/src/PageRouter.tsx
@@ -36,9 +36,6 @@ const PageRouter = observer(({ children }) => {
       etherscanService,
       pinataService,
       coingeckoService,
-      infuraService,
-      alchemyService,
-      customRpcService,
     },
   } = useContext();
 
@@ -50,9 +47,6 @@ const PageRouter = observer(({ children }) => {
   ipfsService.start();
   etherscanService.isAuthenticated();
   pinataService.isAuthenticated();
-  alchemyService.isAuthenticated();
-  infuraService.isAuthenticated();
-  customRpcService.isAuthenticated();
 
   const { active: providerActive } = providerStore.getActiveWeb3React();
 

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -131,17 +131,21 @@ const Header = observer(() => {
         </NavSection>
         {blockchainStore.initialLoadComplete ? (
           <NavSection>
-            {votingMachines.dxd ? (
-              <ItemBox> {dxdBalance} DXD </ItemBox>
-            ) : (
-              <div />
+            {account && (
+              <>
+                {votingMachines.dxd ? (
+                  <ItemBox> {dxdBalance} DXD </ItemBox>
+                ) : (
+                  <div />
+                )}
+                {votingMachines.gen ? (
+                  <ItemBox> {genBalance} GEN </ItemBox>
+                ) : (
+                  <div />
+                )}
+                <ItemBox> {repPercentage.toString()} % REP </ItemBox>
+              </>
             )}
-            {votingMachines.gen ? (
-              <ItemBox> {genBalance} GEN </ItemBox>
-            ) : (
-              <div />
-            )}
-            <ItemBox> {repPercentage.toString()} % REP </ItemBox>
             <Web3ConnectStatus text="Connect Wallet" />
             <NavItem route={`/${networkName}/info`}>
               <a>
@@ -153,11 +157,13 @@ const Header = observer(() => {
                 <FiSettings style={{ margin: '0px 10px', color: '#616161' }} />
               </a>
             </NavItem>
-            <NavItem route={`/${networkName}/user/${account}`}>
-              <a>
-                <FiUser style={{ margin: '0px 10px', color: '#616161' }} />
-              </a>
-            </NavItem>
+            {account && (
+              <NavItem route={`/${networkName}/user/${account}`}>
+                <a>
+                  <FiUser style={{ margin: '0px 10px', color: '#616161' }} />
+                </a>
+              </NavItem>
+            )}
           </NavSection>
         ) : (
           <NavSection>

--- a/src/components/WalletModal/index.tsx
+++ b/src/components/WalletModal/index.tsx
@@ -6,12 +6,12 @@ import { observer } from 'mobx-react';
 import { Modal } from '../Modal';
 import AccountDetails from '../AccountDetails';
 import Option from './Option';
-import { DEFAULT_RPC_URLS, usePrevious } from 'utils';
+import { usePrevious } from 'utils';
 import Link from '../../components/common/Link';
 import { injected, getWallets } from 'provider/connectors';
 import { useContext } from '../../contexts';
 import { isChainIdSupported } from '../../provider/connectors';
-import { useActiveWeb3React } from 'provider/providerHooks';
+import { useActiveWeb3React, useRpcUrls } from 'provider/providerHooks';
 
 const Wrapper = styled.div`
   ${({ theme }) => theme.flexColumnNoWrap}
@@ -96,16 +96,11 @@ const WALLET_VIEWS = {
 
 const WalletModal = observer(() => {
   const {
-    context: {
-      modalStore,
-      infuraService,
-      alchemyService,
-      customRpcService,
-      configStore,
-    },
+    context: { modalStore },
   } = useContext();
   const { active, connector, error, activate, account, chainId } =
     useActiveWeb3React();
+  const rpcUrls = useRpcUrls();
   const [walletView, setWalletView] = useState(WALLET_VIEWS.ACCOUNT);
   const [connectionErrorMessage, setConnectionErrorMessage] = useState(false);
 
@@ -155,7 +150,6 @@ const WalletModal = observer(() => {
   // get wallets user can switch too, depending on device/browser
   function getOptions() {
     const isMetamask = window.ethereum && window.ethereum.isMetaMask;
-    const rpcUrls = getRpcUrls();
     const wallets = getWallets(rpcUrls);
     return Object.keys(wallets).map(key => {
       const option = wallets[key];
@@ -232,19 +226,6 @@ const WalletModal = observer(() => {
         )
       );
     });
-  }
-
-  function getRpcUrls() {
-    const preferredRpc = configStore.getLocalConfig().rpcType;
-    if (preferredRpc == 'infura' && infuraService.auth) {
-      return infuraService.getRpcUrls();
-    } else if (preferredRpc == 'alchemy' && alchemyService.auth) {
-      return alchemyService.getRpcUrls();
-    } else if (preferredRpc == 'custom' && customRpcService.auth) {
-      return customRpcService.getRpcUrls();
-    } else {
-      return DEFAULT_RPC_URLS;
-    }
   }
 
   function getModalContent() {

--- a/src/components/WalletModal/index.tsx
+++ b/src/components/WalletModal/index.tsx
@@ -149,6 +149,8 @@ const WalletModal = observer(() => {
 
   // get wallets user can switch too, depending on device/browser
   function getOptions() {
+    if (!rpcUrls) return [];
+
     const isMetamask = window.ethereum && window.ethereum.isMetaMask;
     const wallets = getWallets(rpcUrls);
     return Object.keys(wallets).map(key => {

--- a/src/components/Web3ReactManager/index.tsx
+++ b/src/components/Web3ReactManager/index.tsx
@@ -38,7 +38,7 @@ const Web3ReactManager = ({ children }) => {
   const triedEager = useEagerConnect();
 
   useEffect(() => {
-    if (triedEager && !networkActive) {
+    if (triedEager && !networkActive && rpcUrls) {
       const networkConnector = getNetworkConnector(rpcUrls);
       activate(networkConnector, undefined, true).catch(e => {
         console.error('[Web3ReactManager] Unable to activate network connector.', e);

--- a/src/components/Web3ReactManager/index.tsx
+++ b/src/components/Web3ReactManager/index.tsx
@@ -1,15 +1,15 @@
-import { useWeb3React } from "@web3-react/core";
-import styled from "styled-components";
-import { getNetworkConnector, web3ContextNames } from "provider/connectors";
+import { useWeb3React } from '@web3-react/core';
+import styled from 'styled-components';
+import { getNetworkConnector, web3ContextNames } from 'provider/connectors';
 import {
   useActiveWeb3React,
   useEagerConnect,
   useInactiveListener,
   useRpcUrls,
-} from "provider/providerHooks";
-import { useContext } from "../../contexts";
-import { useInterval, usePrevious } from "utils";
-import { useEffect } from "react";
+} from 'provider/providerHooks';
+import { useContext } from '../../contexts';
+import { useInterval, usePrevious } from 'utils';
+import { useEffect } from 'react';
 
 const BLOKCHAIN_FETCH_INTERVAL = 10000;
 
@@ -33,7 +33,7 @@ const Web3ReactManager = ({ children }) => {
       web3ContextInjected
     );
 
-  console.debug("[Web3ReactManager] Start of render", {
+  console.debug('[Web3ReactManager] Start of render', {
     injected: web3ContextInjected,
     web3React: providerStore.getActiveWeb3React(),
   });
@@ -44,9 +44,9 @@ const Web3ReactManager = ({ children }) => {
   useEffect(() => {
     if (triedEager && !networkActive && rpcUrls) {
       const networkConnector = getNetworkConnector(rpcUrls);
-      activate(networkConnector, undefined, true).catch((e) => {
+      activate(networkConnector, undefined, true).catch(e => {
         console.error(
-          "[Web3ReactManager] Unable to activate network connector.",
+          '[Web3ReactManager] Unable to activate network connector.',
           e
         );
       });
@@ -55,7 +55,7 @@ const Web3ReactManager = ({ children }) => {
 
   try {
     // @ts-ignore
-    ethereum.on("chainChanged", (chainId) => {
+    ethereum.on('chainChanged', chainId => {
       // Handle the new chain.
       // Correctly handling chain changes can be complicated.
       // We recommend reloading the page unless you have good reason not to.
@@ -65,7 +65,7 @@ const Web3ReactManager = ({ children }) => {
     });
 
     // @ts-ignore
-    ethereum.on("accountsChanged", (accounts) => {
+    ethereum.on('accountsChanged', accounts => {
       // Handle the new accounts, or lack thereof.
       // "accounts" will always be an array, but it can be empty.
       // blockchainStore.fetchData(web3React, false);
@@ -73,7 +73,7 @@ const Web3ReactManager = ({ children }) => {
     });
   } catch (error) {
     console.debug(
-      "[Web3ReactManager] Render: Ethereum Provider not available."
+      '[Web3ReactManager] Render: Ethereum Provider not available.'
     );
   }
 
@@ -128,12 +128,12 @@ const Web3ReactManager = ({ children }) => {
 
   // on page load, do nothing until we've tried to connect to the injected connector
   if (!triedEager) {
-    console.debug("[Web3ReactManager] Render: Eager load not tried");
+    console.debug('[Web3ReactManager] Render: Eager load not tried');
     return null;
   }
   if (networkError) {
     console.debug(
-      "[Web3ReactManager] Render: Network error, showing modal error."
+      '[Web3ReactManager] Render: Network error, showing modal error.'
     );
     return (
       <div>
@@ -145,20 +145,20 @@ const Web3ReactManager = ({ children }) => {
     );
   } else if (prevChainId && chainId && prevChainId !== chainId) {
     // Stop rendering if networks are being switched
-    console.debug("[Web3ReactManager] Render: Switching network", {
+    console.debug('[Web3ReactManager] Render: Switching network', {
       chainId,
       prevChainId,
     });
     return null;
   } else if (!chainId) {
-    console.debug("[Web3ReactManager] Render: No chain ID");
+    console.debug('[Web3ReactManager] Render: No chain ID');
     return null;
   } else if (!networkActive) {
-    console.debug("[Web3ReactManager] Render: No active network");
+    console.debug('[Web3ReactManager] Render: No active network');
     return children;
   } else {
     console.debug(
-      "[Web3ReactManager] Render: Active network, render children",
+      '[Web3ReactManager] Render: Active network, render children',
       { networkActive }
     );
     return children;

--- a/src/components/Web3ReactManager/index.tsx
+++ b/src/components/Web3ReactManager/index.tsx
@@ -1,15 +1,15 @@
-import { useWeb3React } from '@web3-react/core';
-import styled from 'styled-components';
-import { getNetworkConnector, web3ContextNames } from 'provider/connectors';
+import { useWeb3React } from "@web3-react/core";
+import styled from "styled-components";
+import { getNetworkConnector, web3ContextNames } from "provider/connectors";
 import {
   useActiveWeb3React,
   useEagerConnect,
   useInactiveListener,
   useRpcUrls,
-} from 'provider/providerHooks';
-import { useContext } from '../../contexts';
-import { useInterval, usePrevious } from 'utils';
-import { useEffect } from 'react';
+} from "provider/providerHooks";
+import { useContext } from "../../contexts";
+import { useInterval, usePrevious } from "utils";
+import { useEffect } from "react";
 
 const BLOKCHAIN_FETCH_INTERVAL = 10000;
 
@@ -33,7 +33,7 @@ const Web3ReactManager = ({ children }) => {
       web3ContextInjected
     );
 
-  console.debug('[Web3ReactManager] Start of render', {
+  console.debug("[Web3ReactManager] Start of render", {
     injected: web3ContextInjected,
     web3React: providerStore.getActiveWeb3React(),
   });
@@ -44,9 +44,9 @@ const Web3ReactManager = ({ children }) => {
   useEffect(() => {
     if (triedEager && !networkActive && rpcUrls) {
       const networkConnector = getNetworkConnector(rpcUrls);
-      activate(networkConnector, undefined, true).catch(e => {
+      activate(networkConnector, undefined, true).catch((e) => {
         console.error(
-          '[Web3ReactManager] Unable to activate network connector.',
+          "[Web3ReactManager] Unable to activate network connector.",
           e
         );
       });
@@ -55,7 +55,7 @@ const Web3ReactManager = ({ children }) => {
 
   try {
     // @ts-ignore
-    ethereum.on('chainChanged', chainId => {
+    ethereum.on("chainChanged", (chainId) => {
       // Handle the new chain.
       // Correctly handling chain changes can be complicated.
       // We recommend reloading the page unless you have good reason not to.
@@ -65,7 +65,7 @@ const Web3ReactManager = ({ children }) => {
     });
 
     // @ts-ignore
-    ethereum.on('accountsChanged', accounts => {
+    ethereum.on("accountsChanged", (accounts) => {
       // Handle the new accounts, or lack thereof.
       // "accounts" will always be an array, but it can be empty.
       // blockchainStore.fetchData(web3React, false);
@@ -73,13 +73,16 @@ const Web3ReactManager = ({ children }) => {
     });
   } catch (error) {
     console.debug(
-      '[Web3ReactManager] Render: Ethereum Provider not available.'
+      "[Web3ReactManager] Render: Ethereum Provider not available."
     );
   }
 
   const prevChainId = usePrevious(chainId);
   useEffect(() => {
-    if (prevChainId && chainId && prevChainId !== chainId) {
+    if (
+      (prevChainId && !chainId) ||
+      (prevChainId && chainId && prevChainId !== chainId)
+    ) {
       window.location.reload();
     }
   }, [chainId, prevChainId]);
@@ -125,13 +128,12 @@ const Web3ReactManager = ({ children }) => {
 
   // on page load, do nothing until we've tried to connect to the injected connector
   if (!triedEager) {
-    console.debug('[Web3ReactManager] Render: Eager load not tried');
+    console.debug("[Web3ReactManager] Render: Eager load not tried");
     return null;
   }
-
   if (networkError) {
     console.debug(
-      '[Web3ReactManager] Render: Network error, showing modal error.'
+      "[Web3ReactManager] Render: Network error, showing modal error."
     );
     return (
       <div>
@@ -141,13 +143,22 @@ const Web3ReactManager = ({ children }) => {
         <BlurWrapper>{children}</BlurWrapper>
       </div>
     );
-    // If network is not active show blur content
+  } else if (prevChainId && chainId && prevChainId !== chainId) {
+    // Stop rendering if networks are being switched
+    console.debug("[Web3ReactManager] Render: Switching network", {
+      chainId,
+      prevChainId,
+    });
+    return null;
+  } else if (!chainId) {
+    console.debug("[Web3ReactManager] Render: No chain ID");
+    return null;
   } else if (!networkActive) {
-    console.debug('[Web3ReactManager] Render: No active network');
+    console.debug("[Web3ReactManager] Render: No active network");
     return children;
   } else {
     console.debug(
-      '[Web3ReactManager] Render: Active network, render children',
+      "[Web3ReactManager] Render: Active network, render children",
       { networkActive }
     );
     return children;

--- a/src/pages/Configuration.tsx
+++ b/src/pages/Configuration.tsx
@@ -147,7 +147,7 @@ const ConfigPage = observer(() => {
         </span>
       </Row>
 
-      {connector != injected && (
+      {connector !== injected && (
         <>
           <Row style={{ maxWidth: '500px' }}>
             <span

--- a/src/pages/Proposal.tsx
+++ b/src/pages/Proposal.tsx
@@ -499,31 +499,34 @@ const ProposalPage = observer(() => {
               </span>
             )}
         </SidebarRow>
-        <SidebarRow style={{ flexDirection: 'column', alignItems: 'center' }}>
-          {pendingAction === 1 ? (
-            <ActionButton color="blue" onClick={executeProposal}>
-              <FiFastForward /> Boost{' '}
-            </ActionButton>
-          ) : pendingAction === 2 ? (
-            <ActionButton color="blue" onClick={executeProposal}>
-              <FiPlayCircle /> Execute{' '}
-            </ActionButton>
-          ) : pendingAction === 3 ? (
-            <ActionButton color="blue" onClick={executeProposal}>
-              <FiPlayCircle /> Finish{' '}
-            </ActionButton>
-          ) : pendingAction === 4 ? (
-            <ActionButton color="blue" onClick={redeemBeneficiary}>
-              <FiPlayCircle /> Redeem 4 Beneficiary{' '}
-            </ActionButton>
-          ) : (
-            pendingAction === 5 && (
-              <ActionButton color="blue" onClick={executeMulticall}>
-                <FiPlayCircle /> Execute Multicall{' '}
+
+        {account && (
+          <SidebarRow style={{ flexDirection: 'column', alignItems: 'center' }}>
+            {pendingAction === 1 ? (
+              <ActionButton color="blue" onClick={executeProposal}>
+                <FiFastForward /> Boost{' '}
               </ActionButton>
-            )
-          )}
-        </SidebarRow>
+            ) : pendingAction === 2 ? (
+              <ActionButton color="blue" onClick={executeProposal}>
+                <FiPlayCircle /> Execute{' '}
+              </ActionButton>
+            ) : pendingAction === 3 ? (
+              <ActionButton color="blue" onClick={executeProposal}>
+                <FiPlayCircle /> Finish{' '}
+              </ActionButton>
+            ) : pendingAction === 4 ? (
+              <ActionButton color="blue" onClick={redeemBeneficiary}>
+                <FiPlayCircle /> Redeem 4 Beneficiary{' '}
+              </ActionButton>
+            ) : (
+              pendingAction === 5 && (
+                <ActionButton color="blue" onClick={executeMulticall}>
+                  <FiPlayCircle /> Execute Multicall{' '}
+                </ActionButton>
+              )
+            )}
+          </SidebarRow>
+        )}
 
         <SidebarDivider />
 
@@ -681,7 +684,8 @@ const ProposalPage = observer(() => {
           <div />
         )}
 
-        {!finishTimeReached &&
+        {account &&
+        !finishTimeReached &&
         votedAmount.toNumber() === 0 &&
         Number(repPercentageAtCreation) > 0 &&
         proposal.stateInVotingMachine >= 3 ? (
@@ -814,7 +818,8 @@ const ProposalPage = observer(() => {
           <div></div>
         )}
 
-        {!finishTimeReached &&
+        {account &&
+        !finishTimeReached &&
         (proposal.stateInVotingMachine === 3 ||
           proposal.stateInVotingMachine === 4) &&
         votingMachineTokenApproved.toString() === '0' ? (
@@ -827,7 +832,8 @@ const ProposalPage = observer(() => {
               Approve {votingMachineTokenName}
             </ActionButton>
           </SidebarRow>
-        ) : !finishTimeReached &&
+        ) : account &&
+          !finishTimeReached &&
           (proposal.stateInVotingMachine === 3 ||
             proposal.stateInVotingMachine === 4) ? (
           <div>
@@ -909,7 +915,7 @@ const ProposalPage = observer(() => {
           <div></div>
         )}
 
-        {proposal.stateInVotingMachine < 3 &&
+        {account && proposal.stateInVotingMachine < 3 &&
         redeemsLeft.bounty.indexOf(proposalId) > -1 ? (
           <SidebarRow
             style={{

--- a/src/provider/connectors.ts
+++ b/src/provider/connectors.ts
@@ -38,7 +38,7 @@ export function getNetworkConnector(customRpcUrls: {
 }) {
   return new NetworkConnector({
     urls: customRpcUrls,
-    defaultChainId: 1,
+    defaultChainId: DEFAULT_ETH_CHAIN_ID,
   });
 }
 

--- a/src/provider/connectors.ts
+++ b/src/provider/connectors.ts
@@ -1,5 +1,6 @@
 import { InjectedConnector } from '@web3-react/injected-connector';
 import { WalletConnectConnector } from '@web3-react/walletconnect-connector';
+import { NetworkConnector } from '@web3-react/network-connector';
 import { NETWORK_IDS } from '../utils';
 import metamaskIcon from '../assets/images/metamask.png';
 import walletConnectIcon from '../assets/images/walletconnect.png';
@@ -32,6 +33,15 @@ export function getWalletConnectConnector(customRpcUrls: {
   });
 }
 
+export function getNetworkConnector(customRpcUrls: {
+  [chainId: number]: string;
+}) {
+  return new NetworkConnector({
+    urls: customRpcUrls,
+    defaultChainId: 1,
+  });
+}
+
 export const getWallets = (customRpcUrls: { [chainId: number]: string }) => ({
   INJECTED: {
     connector: injected,
@@ -59,7 +69,3 @@ export const getWallets = (customRpcUrls: { [chainId: number]: string }) => ({
     icon: walletConnectIcon,
   },
 });
-
-export default {
-  injected,
-};

--- a/src/provider/providerHooks.ts
+++ b/src/provider/providerHooks.ts
@@ -101,15 +101,28 @@ export function useRpcUrls() {
   const {
     context: { infuraService, alchemyService, customRpcService, configStore },
   } = useContext();
-
   const preferredRpc = configStore.getLocalConfig().rpcType;
-  if (preferredRpc === 'infura' && infuraService.auth) {
-    return infuraService.getRpcUrls();
-  } else if (preferredRpc === 'alchemy' && alchemyService.auth) {
-    return alchemyService.getRpcUrls();
-  } else if (preferredRpc === 'custom' && customRpcService.auth) {
-    return customRpcService.getRpcUrls();
-  } else {
-    return DEFAULT_RPC_URLS;
+  const [rpcUrls, setRpcUrls] = useState(null);
+
+  useEffect(() => {
+    getRpcUrls().then(urls => setRpcUrls(urls));
+  }, [preferredRpc]);
+
+  async function getRpcUrls() {
+    await alchemyService.isAuthenticated();
+    await infuraService.isAuthenticated();
+    await customRpcService.isAuthenticated();
+
+    if (preferredRpc === 'infura' && infuraService.auth) {
+      return infuraService.getRpcUrls();
+    } else if (preferredRpc === 'alchemy' && alchemyService.auth) {
+      return alchemyService.getRpcUrls();
+    } else if (preferredRpc === 'custom' && customRpcService.auth) {
+      return customRpcService.getRpcUrls();
+    } else {
+      return DEFAULT_RPC_URLS;
+    }
   }
+
+  return rpcUrls;
 }

--- a/src/provider/providerHooks.ts
+++ b/src/provider/providerHooks.ts
@@ -2,6 +2,8 @@ import { useEffect, useState } from 'react';
 import { useWeb3React as useWeb3ReactCore } from '@web3-react/core';
 import { isMobile } from 'react-device-detect';
 import { injected, web3ContextNames } from 'provider/connectors';
+import { useContext } from 'contexts';
+import { DEFAULT_RPC_URLS } from 'utils';
 
 /*  Attempt to connect to & activate injected connector
     If we're on mobile and have an injected connector, attempt even if not authorized (legacy support)
@@ -93,4 +95,21 @@ export function useInactiveListener(suppress = false) {
 
     return () => {};
   }, [active, error, suppress, activate]);
+}
+
+export function useRpcUrls() {
+  const {
+    context: { infuraService, alchemyService, customRpcService, configStore },
+  } = useContext();
+
+  const preferredRpc = configStore.getLocalConfig().rpcType;
+  if (preferredRpc === 'infura' && infuraService.auth) {
+    return infuraService.getRpcUrls();
+  } else if (preferredRpc === 'alchemy' && alchemyService.auth) {
+    return alchemyService.getRpcUrls();
+  } else if (preferredRpc === 'custom' && customRpcService.auth) {
+    return customRpcService.getRpcUrls();
+  } else {
+    return DEFAULT_RPC_URLS;
+  }
 }

--- a/src/stores/UserStore.ts
+++ b/src/stores/UserStore.ts
@@ -44,6 +44,8 @@ export default class UserStore {
     const networkContracts = configStore.getNetworkContracts();
     const account = web3React.account;
 
+    if (!account) return;
+
     transactionStore.checkPendingTransactions(web3React, account);
     let callsToExecute = [
       [

--- a/src/stores/UserStore.ts
+++ b/src/stores/UserStore.ts
@@ -1,4 +1,4 @@
-import { makeObservable, observable, action } from 'mobx';
+import { makeObservable, observable, action, runInAction } from 'mobx';
 import { Web3ReactContextInterface } from '@web3-react/core/dist/types';
 import RootContext from '../contexts';
 import { ContractType } from './Provider';
@@ -150,6 +150,8 @@ export default class UserStore {
         ? bnum(callsResponse.decodedReturnData[2])
         : bnum(0);
 
-    this.userInfo = userInfo;
+    runInAction(() => {
+      this.userInfo = userInfo;
+    });
   }
 }


### PR DESCRIPTION
Now DXvote loads and shows proposals even when a wallet is not connected! This is achieved by using `@web3-react/network-connector` to load proposals via RPC URLs.

The app is currently connecting to Mainnet automatically on visit, as this is hardcoded in the network connector's configuration. This will be solved when we introduce the network switcher.

Fixes https://github.com/DXgovernance/dxvote/issues/89.