### PR TITLE
fix: Fixing if statement and utils methods for redemptions

### DIFF
--- a/src/stores/DaoStore.ts
+++ b/src/stores/DaoStore.ts
@@ -869,13 +869,13 @@ export default class DaoStore {
       const voteParameters = this.getVotingParametersOfProposal(
         vote.proposalId
       );
-
       if (
-        isExpired(proposal) &&
-        hasLostReputation(voteParameters) &&
-        votedBeforeBoosted(proposal, vote) &&
-        isWinningVote(proposal, vote) &&
-        redeemsLeft.rep.indexOf(vote.proposalId) < 0
+        (isExpired(proposal) && votedBeforeBoosted(proposal, vote)) ||
+        (hasLostReputation(voteParameters) &&
+          votedBeforeBoosted(proposal, vote) &&
+          isWinningVote(proposal, vote) &&
+          isNotActive(proposal) &&
+          redeemsLeft.rep.indexOf(vote.proposalId) < 0)
       ) {
         redeemsLeft.rep.push(vote.proposalId);
       }
@@ -899,7 +899,6 @@ export default class DaoStore {
         }
       }
     });
-
     // Remove already redeemed
     userEvents.redeemsRep.map(redeemRep => {
       if (redeemsLeft.rep.indexOf(redeemRep.proposalId) > -1)

--- a/src/utils/proposals.ts
+++ b/src/utils/proposals.ts
@@ -11,11 +11,14 @@ export const isExpired = (proposal: Proposal): boolean => {
   );
 };
 
+// Checks for whether vote was made before boosting activated
+// Returns false if proposal was not boosted at all
 export const votedBeforeBoosted = (proposal: Proposal, vote: Vote): boolean => {
   const boosted = proposal.boostedPhaseTime.toNumber() > 0;
   const votedBeforeBoosted =
     vote.timestamp < proposal.boostedPhaseTime.toNumber();
-  return boosted && votedBeforeBoosted;
+  const notBoosted = proposal.boostedPhaseTime.toNumber() === 0;
+  return (boosted && votedBeforeBoosted) || notBoosted;
 };
 
 export const isNotActive = (proposal: Proposal): boolean => {


### PR DESCRIPTION
We had a regression issue where the redeem button was once again not appearing on proposals where it should.
Although not directly related to the previous fix it is still something we should have caught.
During a refactor of a complex if statement it seems some logic was changed where the conditions were not properly grouped together and the new util removed a check for unboosted proposals causing the statement to be false.

There are many complex if conditions throughout the code that need refactored for this exact reason that it is difficult to understand. So we need to do this more, however we also have to be extra careful to go through and test the new refactor. 

#196 should help us here, if for example we find a regression like this or even if we refactor a conditional statement like this we should add a few tests to cover all the logic. 

Closes #195 