### PR TITLE
fix: Removing additional min stake in proposals page

### DIFF
--- a/src/pages/Proposals.tsx
+++ b/src/pages/Proposals.tsx
@@ -335,9 +335,6 @@ const ProposalsPage = observer(() => {
                 (schemeFilter === 'All Schemes' ||
                   proposal.scheme === schemeFilter)
               ) {
-                // const minimumDaoBounty = daoStore.getVotingParametersOfProposal(
-                //   proposal.id
-                // ).minimumDaoBounty;
                 const positiveStake = formatNumberValue(
                   normalizeBalance(proposal.positiveStakes, 18),
                   1

--- a/src/pages/Proposals.tsx
+++ b/src/pages/Proposals.tsx
@@ -335,18 +335,15 @@ const ProposalsPage = observer(() => {
                 (schemeFilter === 'All Schemes' ||
                   proposal.scheme === schemeFilter)
               ) {
-                const minimumDaoBounty = daoStore.getVotingParametersOfProposal(
-                  proposal.id
-                ).minimumDaoBounty;
+                // const minimumDaoBounty = daoStore.getVotingParametersOfProposal(
+                //   proposal.id
+                // ).minimumDaoBounty;
                 const positiveStake = formatNumberValue(
                   normalizeBalance(proposal.positiveStakes, 18),
                   1
                 );
                 const negativeStake = formatNumberValue(
-                  normalizeBalance(
-                    proposal.negativeStakes.plus(minimumDaoBounty),
-                    18
-                  ),
+                  normalizeBalance(proposal.negativeStakes, 18),
                   1
                 );
                 const repAtCreation = daoStore.getRepAt(


### PR DESCRIPTION
It seems the min downstake is already included in the downstakle amount and so by adding it back we ad this bug of it showing double the amount on the proposals page.

Let me know if I missed something and there is a case where we need this but in testing I could not find any.

Closes #210 