### PR TITLE
feat: Added calls to new swapr campaign creation template

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -240,6 +240,25 @@
         "name": "Signal Proposal",
         "title": "Signal Proposal for [DAO_ACTION]",
         "description": "## Description \n\n## Proposition \n\n## Action Plan"
+      },
+      {
+        "name": "SWPR Farming Campaign",
+        "title": "[PAIR X/Y] Farming Campaign [DATE - DATE]]",
+        "description": "Simple description",
+        "calls": [
+          {
+            "functionName": "createDistribution(address[],address,uint256[],uint64,uint64,bool,uint256)",
+            "params": [
+              {"id": "rewardsTokenAddresses", "defaultValue": "0xecA7F78d59D16812948849663b26FE10E320f80C"},
+              null,
+              null,
+              null,
+              null,
+              {"id": "locked", "defaultValue": "false"},
+              {"id": "stakingCap", "defaultValue": "0"}
+            ]
+          }
+        ]
       }
     ],
     "tokens": [
@@ -2012,6 +2031,31 @@
         "name": "Signal Proposal",
         "title": "Signal Proposal for [DAO_ACTION]",
         "description": "## Description \n\n## Proposition \n\n## Action Plan"
+      },
+      {
+        "name": "SWPR Farming Campaign",
+        "title": "[PAIR X/Y] Farming Campaign [DATE - DATE]]",
+        "description": "Simple description",
+        "calls": [
+          {
+            "to": "0xdE903E2712288A1dA82942DDdF2c20529565aC30",
+            "functionName": "approve(address,uint256)",
+            "params": ["0xecA7F78d59D16812948849663b26FE10E320f80C",""]
+          },
+          {
+            "to": "0xecA7F78d59D16812948849663b26FE10E320f80C",
+            "functionName": "createDistribution(address[],address,uint256[],uint64,uint64,bool,uint256)",
+            "params": [
+              "0xecA7F78d59D16812948849663b26FE10E320f80C",
+              "",
+              "",
+              "",
+              "",
+              "false",
+              "0"
+            ]
+          }
+        ]
       }
     ],
     "tokens": [

--- a/src/config.json
+++ b/src/config.json
@@ -247,15 +247,21 @@
         "description": "Simple description",
         "calls": [
           {
+            "to": "0xdE903E2712288A1dA82942DDdF2c20529565aC30",
+            "functionName": "approve(address,uint256)",
+            "params": ["0xecA7F78d59D16812948849663b26FE10E320f80C",""]
+          },
+          {
+            "to": "0xecA7F78d59D16812948849663b26FE10E320f80C",
             "functionName": "createDistribution(address[],address,uint256[],uint64,uint64,bool,uint256)",
             "params": [
-              {"id": "rewardsTokenAddresses", "defaultValue": "0xecA7F78d59D16812948849663b26FE10E320f80C"},
-              null,
-              null,
-              null,
-              null,
-              {"id": "locked", "defaultValue": "false"},
-              {"id": "stakingCap", "defaultValue": "0"}
+              "0xecA7F78d59D16812948849663b26FE10E320f80C",
+              "",
+              "",
+              "",
+              "",
+              "false",
+              "0"
             ]
           }
         ]
@@ -898,6 +904,31 @@
         "name": "Signal Proposal",
         "title": "Signal Proposal for [DAO_ACTION]",
         "description": "## Description \n\n## Proposition \n\n## Action Plan"
+      },
+      {
+        "name": "SWPR Farming Campaign",
+        "title": "[PAIR X/Y] Farming Campaign [DATE - DATE]]",
+        "description": "Simple description",
+        "calls": [
+          {
+            "to": "0xdE903E2712288A1dA82942DDdF2c20529565aC30",
+            "functionName": "approve(address,uint256)",
+            "params": ["0xecA7F78d59D16812948849663b26FE10E320f80C",""]
+          },
+          {
+            "to": "0xecA7F78d59D16812948849663b26FE10E320f80C",
+            "functionName": "createDistribution(address[],address,uint256[],uint64,uint64,bool,uint256)",
+            "params": [
+              "0xecA7F78d59D16812948849663b26FE10E320f80C",
+              "",
+              "",
+              "",
+              "",
+              "false",
+              "0"
+            ]
+          }
+        ]
       }
     ],
     "tokens": [
@@ -1600,6 +1631,31 @@
         "name": "Signal Proposal",
         "title": "Signal Proposal for [DAO_ACTION]",
         "description": "## Description \n\n## Proposition \n\n## Action Plan"
+      },
+      {
+        "name": "SWPR Farming Campaign",
+        "title": "[PAIR X/Y] Farming Campaign [DATE - DATE]]",
+        "description": "Simple description",
+        "calls": [
+          {
+            "to": "0xdE903E2712288A1dA82942DDdF2c20529565aC30",
+            "functionName": "approve(address,uint256)",
+            "params": ["0xecA7F78d59D16812948849663b26FE10E320f80C",""]
+          },
+          {
+            "to": "0xecA7F78d59D16812948849663b26FE10E320f80C",
+            "functionName": "createDistribution(address[],address,uint256[],uint64,uint64,bool,uint256)",
+            "params": [
+              "0xecA7F78d59D16812948849663b26FE10E320f80C",
+              "",
+              "",
+              "",
+              "",
+              "false",
+              "0"
+            ]
+          }
+        ]
       }
     ],
     "tokens": [
@@ -2447,6 +2503,31 @@
         "name": "Signal Proposal",
         "title": "Signal Proposal for [DAO_ACTION]",
         "description": "## Description \n\n## Proposition \n\n## Action Plan"
+      },
+      {
+        "name": "SWPR Farming Campaign",
+        "title": "[PAIR X/Y] Farming Campaign [DATE - DATE]]",
+        "description": "Simple description",
+        "calls": [
+          {
+            "to": "0xdE903E2712288A1dA82942DDdF2c20529565aC30",
+            "functionName": "approve(address,uint256)",
+            "params": ["0xecA7F78d59D16812948849663b26FE10E320f80C",""]
+          },
+          {
+            "to": "0xecA7F78d59D16812948849663b26FE10E320f80C",
+            "functionName": "createDistribution(address[],address,uint256[],uint64,uint64,bool,uint256)",
+            "params": [
+              "0xecA7F78d59D16812948849663b26FE10E320f80C",
+              "",
+              "",
+              "",
+              "",
+              "false",
+              "0"
+            ]
+          }
+        ]
       }
     ],
     "tokens": [

--- a/src/pages/NewProposal.tsx
+++ b/src/pages/NewProposal.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { observer } from 'mobx-react';
 import { useContext } from '../contexts';
-import {Box, Question, Button } from '../components/common';
+import { Box, Question, Button } from '../components/common';
 import MDEditor, { commands } from '@uiw/react-md-editor';
 import contentHash from 'content-hash';
 import { NETWORK_ASSET_SYMBOL } from '../utils';
@@ -472,7 +472,7 @@ const NewProposalPage = observer(() => {
   }
 
   function onToSelectChange(callIndex, toAddress) {
-    console.log(toAddress);
+    console.log({ toAddress });
     if (toAddress === ANY_ADDRESS) {
       changeCallType(callIndex);
     } else {
@@ -556,15 +556,33 @@ const NewProposalPage = observer(() => {
   }
 
   function onProposalTemplate(event) {
-    if (proposalTemplates[event.target.value].name !== 'Custom') {
-      setTitleText(proposalTemplates[event.target.value].title);
-      setDescriptionText(proposalTemplates[event.target.value].description);
+    const selectedTemplate = proposalTemplates[event.target.value];
+    if (selectedTemplate.name !== 'Custom') {
+      setTitleText(selectedTemplate.title);
+      setDescriptionText(selectedTemplate.description);
       calls.splice(0, calls.length);
+      if (selectedTemplate.calls) {
+        selectedTemplate.calls.forEach((call, index) => {
+          addCall();
+          onToSelectChange(index, call.to);
+          const selectedFunction = calls[index].allowedFunctions.find(
+            allowedFunction => {
+              return allowedFunction.functionName === call.functionName;
+            }
+          );
+          onFunctionSelectChange(
+            index,
+            call.functionName,
+            selectedFunction.params
+          );
+          calls[index].dataValues = call.params;
+        });
+      }
+
       setCallsInState(calls);
     }
   }
-
-
+  console.log({ calls });
   return (
     <NewProposalFormWrapper>
       <div

--- a/src/pages/NewProposal.tsx
+++ b/src/pages/NewProposal.tsx
@@ -582,7 +582,7 @@ const NewProposalPage = observer(() => {
       setCallsInState(calls);
     }
   }
-  console.log({ calls });
+
   return (
     <NewProposalFormWrapper>
       <div

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -293,6 +293,7 @@ declare global {
       name: string;
       title: string;
       description: string;
+      calls?: array;
     }[];
     tokens: {
       address: string;


### PR DESCRIPTION
Requested by @jpkcambridge we now have automatic filling of calls when selecting a template.
This is optional and only currently implemented for swapr campaign creation in an attempt to reduce human error and make new proposal creation for fortnightly epochs simpler.

Closes #219 