### PR TITLE
Add release note script for develop to master PRs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.release.md

--- a/scripts/developRelease.sh
+++ b/scripts/developRelease.sh
@@ -1,0 +1,2 @@
+echo "| Commit   |      Author      |  Message | \n |----------|:-------------:|:------|" > .release.md
+git log master..develop --pretty="|[%H](https://github.com/DXgovernance/dxvote/commit/%H)| %cn | %s|" --full-history --no-merges --reverse >> .release.md


### PR DESCRIPTION
The developRelease.sh script will create a .release.md file with a table that can be used as release nots in PRs from develop to master :)