### PR TITLE
Improve MetaMask UX

### DIFF
--- a/src/components/Web3ReactManager/index.tsx
+++ b/src/components/Web3ReactManager/index.tsx
@@ -72,7 +72,8 @@ const Web3ReactManager = ({ children }) => {
     const chains = getChains(rpcUrls);
     const chain = chains.find(chain => chain.id == chainId);
 
-    if (chain) {
+    const urlNetworkName = location.pathname.split('/')[1];
+    if (chain && chain.name != urlNetworkName) {
       history.push(`/${chain.name}/proposals`);
     }
     

--- a/src/provider/connectors.ts
+++ b/src/provider/connectors.ts
@@ -77,9 +77,9 @@ export const getWallets = (
   },
 });
 
-export const getChains = (customRpcUrls: Record<ChainConfig['id'], string>) => {
+export const getChains = (customRpcUrls?: Record<ChainConfig['id'], string>) => {
   return ACTIVE_NETWORKS.map(network => ({
     ...network,
-    rpcUrl: customRpcUrls[network.id] || network.defaultRpc,
+    rpcUrl: customRpcUrls?.[network.id] || network.defaultRpc,
   }));
 };


### PR DESCRIPTION
This PR changes the behavior of MetaMask and other injected wallets. Currently, the browser prioritizes the MetaMask connection, and eagerly connects to it whenever it's present. While this works generally, the issue is when someone wants to directly access a  proposal via a link, they have to first switch to the correct network on MetaMask manually.

This PR fixes this by only eager-connecting if the network is the same.
1. When visiting the DXvote homepage, by default it connects to mainnet.
2. The user is able to switch networks without switching it in MetaMask.
3. If MetaMask or other injected wallet is found, the active network of that wallet is checked.
4. If the wallet is on the same network DXvote is in, we will eagerly connect.
5. If not, the user is alerted to switch the wallet to the network DXvote is in.

![image](https://user-images.githubusercontent.com/25136207/137322023-6d61bc24-dbfc-4176-9f68-fefc3cc46726.png)

**Sidenote**
- Web3 provider implementation in DXvote needs some refactoring and cleaning up. There's a lot of stuff we don't use, and there's some code duplication. Its better to revisit this later.

Fixes #242.