### PR TITLE
feat: Improve deployment behavior for IPFS.

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -1,0 +1,43 @@
+name: Code Build
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+      - develop
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [14.17.6]
+    steps:
+      - name: Inject workflow information
+        uses: potiuk/get-workflow-origin@v1_3
+        id: workflow-run-info
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Build dapp
+        run: CI=false yarn build
+
+      - name: Archive artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ steps.workflow-run-info.outputs.targetCommitSha }}
+          path: build/

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -8,7 +8,6 @@ jobs:
   cleanup:
     name: Remove test environment deployment
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/develop' || github.ref != 'refs/heads/master'
     steps:
       - name: Get build workflow details
         uses: potiuk/get-workflow-origin@v1_3
@@ -19,6 +18,7 @@ jobs:
 
       - name: Mark deployment as deactivated
         uses: bobheadxi/deployments@v0.6.0
+        if: steps.source-run-info.outputs.sourceHeadBranch != 'develop' || steps.source-run-info.outputs.sourceHeadBranch != 'master'
         with:
           step: deactivate-env
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -1,0 +1,25 @@
+name: IPFS Deploy - Cleanup
+
+on:
+  pull_request_target:
+    types: [closed]
+
+jobs:
+  cleanup:
+    name: Remove test environment deployment
+    runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/develop' || github.ref != 'refs/heads/master'
+    steps:
+      - name: Get build workflow details
+        uses: potiuk/get-workflow-origin@v1_3
+        id: source-run-info
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sourceRunId: ${{ github.event.workflow_run.id }}
+
+      - name: Mark deployment as deactivated
+        uses: bobheadxi/deployments@v0.6.0
+        with:
+          step: deactivate-env
+          token: ${{ secrets.GITHUB_TOKEN }}
+          env: ${{ steps.source-run-info.outputs.sourceHeadBranch }}

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -1,41 +1,49 @@
-name: IPFS Preview Deploy
+name: IPFS Deploy
 
 on:
-  workflow_dispatch:
-  push:
-    branches:
-      - master
-      - develop
-  pull_request_target:
-    types: [synchronize, edited, opened, converted_to_draft, ready_for_review, reopened]
+  workflow_run:
+    workflows: ["Code Build"]
+    types:
+      - completed
 
 jobs:
-  develop-ci:
+  deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
         node-version: [14.17.6]
     steps:
-      - name: Inject slug variables
-        uses: rlespinasse/github-slug-action@3.5.1
-
-      - name: Checkout
-        uses: actions/checkout@v2
+      - name: Get build workflow details
+        uses: potiuk/get-workflow-origin@v1_3
+        id: source-run-info
         with:
-          fetch-depth: 0
-          ref: ${{github.event.pull_request.head.ref}}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sourceRunId: ${{ github.event.workflow_run.id }}
 
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+      - name: Start Deployment
+        uses: bobheadxi/deployments@v0.6.0
+        id: deployment
         with:
-          node-version: ${{ matrix.node-version }}
+          step: start
+          token: ${{ secrets.GITHUB_TOKEN }}
+          env: ${{ steps.source-run-info.outputs.sourceHeadBranch }}
+          no_override: false
+          ref: ${{ steps.source-run-info.outputs.sourceHeadBranch }}
 
-      - name: Install dependencies
-        run: yarn
+      - name: Download artifact from build workflow
+        uses: synergy-au/download-workflow-artifacts-action@v1
+        with:
+          workflow-run-id: ${{ github.event.workflow_run.id }}
 
-      - name: Build Dapp
-        run: CI=false yarn build
+      - name: Download artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: preview-build.yml
+          workflow_conclusion: success
+          name: ${{ steps.source-run-info.outputs.targetCommitSha }}
+          commit: ${{ steps.source-run-info.outputs.targetCommitSha }}
+          path: 'build'
 
       - name: Deploy to IPFS
         uses: web3-storage/add-to-web3@v1
@@ -44,14 +52,35 @@ jobs:
           web3_token: ${{ secrets.WEB3_STORAGE_TOKEN }}
           path_to_add: 'build'
  
-      - name: Update DNS Record for Develop Branch
+      - name: Update DNS record for Develop branch
         run: npx dnslink-cloudflare --domain dxvote.dev --record _dnslink.develop --link /ipfs/${{ steps.web3.outputs.cid }}
         env:
           CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
-        if: github.ref == 'refs/heads/develop'
+        if: steps.source-run-info.outputs.sourceHeadRepo == 'DXgovernance/dxvote' && steps.source-run-info.outputs.sourceHeadBranch == 'develop'
 
-      - name: Update DNS Record for Master Branch
+      - name: Update DNS record for Master branch
         run: npx dnslink-cloudflare --domain dxvote.dev --record _dnslink --link /ipfs/${{ steps.web3.outputs.cid }}
         env:
           CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
-        if: github.ref == 'refs/heads/master'
+        if: steps.source-run-info.outputs.sourceHeadRepo == 'DXgovernance/dxvote' && steps.source-run-info.outputs.sourceHeadBranch == 'master'
+
+      - name: Update Deployment Status
+        uses: bobheadxi/deployments@v0.6.0
+        with:
+          step: finish
+          token: ${{ secrets.GITHUB_TOKEN }}
+          status: ${{ job.status }}
+          deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+          env_url: 'https://${{ steps.web3.outputs.cid }}.ipfs.dweb.link'
+
+      - name: Create comment with status
+        uses: peter-evans/create-or-update-comment@v1
+        if: ${{ steps.source-run-info.outputs.pullRequestNumber }}
+        with:
+          issue-number: ${{ steps.source-run-info.outputs.pullRequestNumber }}
+          body: |
+            ✔️ Preview deployment is ready!
+
+            🔨 Explore the source changes: ${{ steps.source-run-info.outputs.mergeCommitSha }}
+
+            😎 Browse the preview: https://${{ steps.web3.outputs.cid }}.ipfs.dweb.link

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -31,18 +31,12 @@ jobs:
           no_override: false
           ref: ${{ steps.source-run-info.outputs.sourceHeadBranch }}
 
-      - name: Download artifact from build workflow
-        uses: synergy-au/download-workflow-artifacts-action@v1
-        with:
-          workflow-run-id: ${{ github.event.workflow_run.id }}
-
       - name: Download artifact
         uses: dawidd6/action-download-artifact@v2
         with:
           workflow: preview-build.yml
           workflow_conclusion: success
           name: ${{ steps.source-run-info.outputs.targetCommitSha }}
-          commit: ${{ steps.source-run-info.outputs.targetCommitSha }}
           path: 'build'
 
       - name: Deploy to IPFS


### PR DESCRIPTION
This is a complete overhaul of the IPFS deployments GitHub actions we had previously.

With this change, the deployment actions are split into three different pipelines.
1. Build pipeline - Builds the frontend and archives the build output as an artifact.
2. Deploy pipeline - Deploys the latest build artifact into IPFS. Spawns automatically when the build pipelines finishes.
3. Cleanup pipeline - Cleans up the deployment when a PR is merged.

Previously we had an issue of the deployment failing when opening a PR from a fork. GitHub doesn't provide write access to the pipeline in this case for security reasons. The new setup works around this limitation by splitting the build and deployment into two pipelines. The build pipeline still runs with limited permissions, but spawns the deployment pipeline afterwards. This spawned pipeline has full privileges, and completes the deployment.

This PR also handles Environments in GitHub gracefully, and also leaves a comment when a deployment is completed successfully for good measure.

Caveats:
- Secrets are not provided to PRs from forks (intentionally). I suggest to move the Alchemy API key (which should be the only secret that is affected) to our environment configs in the code. It's not really a "secret" as its anyway exposed to the user.

Fixes #258.

**This PR needs to be merged into `master` for everything to work as expected. I'd hold off merging this until we're ready for the next release, as merging this will affect the current deployment setup.**
