### PR TITLE
Fix/default provider setup

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,3 +1,4 @@
 REACT_APP_VERSION=$npm_package_version
 NODE_ENV=production
 REACT_APP_ETH_NETWORKS=mainnet,xdai,arbitrum,rinkeby,arbitrumTestnet
+REACT_APP_KEY_ALCHEMY_API_KEY=7i7fiiOx1b7bGmgWY_oI9twyQBCsuXKC

--- a/src/provider/providerHooks.ts
+++ b/src/provider/providerHooks.ts
@@ -33,10 +33,15 @@ export function useEagerConnect() {
         isAuthorized,
       });
 
-      const injectedChainId = await injected.getChainId();
-      if (injectedChainId != urlChainIdHex) {
+      try {
+        const injectedChainId = await injected.getChainId();
+        if (injectedChainId != urlChainIdHex) {
+          setTried(true);
+          return;
+        }
+      } catch (error) {
+        console.error(error);
         setTried(true);
-        return;
       }
 
       if (isAuthorized) {


### PR DESCRIPTION
- Adds default alchemy API key in env.production file. The RPC is whitelisted to only work with `dxvote.dev` and `dxvote.eth.link` domains.
- Fix bug that breaks the app when trying to load dxvote without any ethereum provider installed in the browser.