### PR TITLE
an initial react-datetime setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "react": "^16.10.2",
     "react-app-rewired": "^2.1.6",
     "react-countdown": "^2.3.2",
+    "react-datetime": "^3.1.1",
     "react-device-detect": "^1.17.0",
     "react-dom": "^16.10.2",
     "react-feather": "^2.0.3",

--- a/src/components/common/Forms/InputDate.tsx
+++ b/src/components/common/Forms/InputDate.tsx
@@ -1,0 +1,9 @@
+import Datetime from 'react-datetime';
+import 'react-datetime/css/react-datetime.css';
+
+// This is an example of usage of a component
+// In the form we can use <Datetime value{controledValue} />
+// and contorledValue.unix() to get the timestamp.
+// https://www.npmjs.com/package/react-datetime API here
+// for example: onChange, onClose, onNavigate, etc.
+export const InputDate = () => <Datetime />;

--- a/src/components/common/Forms/index.ts
+++ b/src/components/common/Forms/index.ts
@@ -1,0 +1,1 @@
+export { InputDate } from './InputDate';

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -21,3 +21,5 @@ export {
   AmountBadge,
   HorizontalSeparator,
 } from './Votes';
+
+export { InputDate } from './Forms';

--- a/src/pages/NewProposal.tsx
+++ b/src/pages/NewProposal.tsx
@@ -2,7 +2,7 @@ import { useReducer, useState } from 'react';
 import styled from 'styled-components';
 import { observer } from 'mobx-react';
 import { useContext } from '../contexts';
-import { Box, Question, Button, InputDate } from '../components/common';
+import { Box, Question, Button } from '../components/common';
 import MDEditor, { commands } from '@uiw/react-md-editor';
 import contentHash from 'content-hash';
 
@@ -822,7 +822,6 @@ const NewProposalPage = observer(() => {
               value={contributionRewardCalls.externalToken}
               width="50%"
             />
-            <InputDate />
             <TextInput
               type="text"
               onChange={event =>

--- a/src/pages/NewProposal.tsx
+++ b/src/pages/NewProposal.tsx
@@ -2,7 +2,7 @@ import { useReducer, useState } from 'react';
 import styled from 'styled-components';
 import { observer } from 'mobx-react';
 import { useContext } from '../contexts';
-import { Box, Question, Button } from '../components/common';
+import { Box, Question, Button, InputDate } from '../components/common';
 import MDEditor, { commands } from '@uiw/react-md-editor';
 import contentHash from 'content-hash';
 
@@ -822,6 +822,7 @@ const NewProposalPage = observer(() => {
               value={contributionRewardCalls.externalToken}
               width="50%"
             />
+            <InputDate />
             <TextInput
               type="text"
               onChange={event =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -15849,7 +15849,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.0.0, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.0.0, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -16182,6 +16182,13 @@ react-countdown@^2.3.2:
   integrity sha512-Q4SADotHtgOxNWhDdvgupmKVL0pMB9DvoFcxv5AzjsxVhzOVxnttMbAywgqeOdruwEAmnPhOhNv/awAgkwru2w==
   dependencies:
     prop-types "^15.7.2"
+
+react-datetime@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/react-datetime/-/react-datetime-3.1.1.tgz#adc346efda47653cfff9259c979f03f56106e48c"
+  integrity sha512-gHCTjAniCcMb6jdXpz+MpVe/uCeaHNDOofg+l41nLlJI3uBLBMV40CQbGB2TCTUpCzGT1mCs4vQzKGMjXO/WWQ==
+  dependencies:
+    prop-types "^15.5.7"
 
 react-dev-utils@^11.0.3:
   version "11.0.4"


### PR DESCRIPTION
Done: 
- install react-datetime package. It provides a UI input element with a complete API to manage date in other components (as forms, etc. ) https://www.npmjs.com/package/react-datetime
- A simple InputDate raw component that renders an input with a calendar to pick from. 

Usage: 
- wherever we need input dates, we should use a <Datetime > with value as prop for controlled forms. 
- we can wrap it in a StyledComponent based on the  use case when needed. 
