### PR TITLE
feat: Make proposals list titles right-clickable.

### DIFF
--- a/src/pages/Proposals.tsx
+++ b/src/pages/Proposals.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import styled from 'styled-components';
-import { useHistory } from 'react-router-dom';
+import { useHistory, Link } from 'react-router-dom';
 import { observer } from 'mobx-react';
 import MiniSearch from 'minisearch';
 import { useContext } from '../contexts';
@@ -145,6 +145,11 @@ const TableProposal = styled(Table)`
       top: 0;
     }
   }
+`;
+
+const UnstyledAnchor = styled.a`
+  color: inherit;
+  text-decoration: inherit;
 `;
 
 const ProposalsPage = observer(() => {
@@ -420,22 +425,24 @@ const ProposalsPage = observer(() => {
                   fontSize="inherit"
                   align="left"
                 >
-                  {created && (
-                    <FiFeather
-                      style={{ minWidth: '15px', margin: '0px 2px' }}
-                    />
-                  )}
-                  {voted && (
-                    <FiCheckCircle
-                      style={{ minWidth: '15px', margin: '0px 2px' }}
-                    />
-                  )}
-                  {staked && (
-                    <FiCheckSquare
-                      style={{ minWidth: '15px', margin: '0px 2px' }}
-                    />
-                  )}
-                  {proposal.title.length > 0 ? proposal.title : proposal.id}
+                  <Link to={`/${networkName}/proposal/${proposal.id}`} component={UnstyledAnchor}>
+                    {created && (
+                      <FiFeather
+                        style={{ minWidth: '15px', margin: '0px 2px' }}
+                      />
+                    )}
+                    {voted && (
+                      <FiCheckCircle
+                        style={{ minWidth: '15px', margin: '0px 2px' }}
+                      />
+                    )}
+                    {staked && (
+                      <FiCheckSquare
+                        style={{ minWidth: '15px', margin: '0px 2px' }}
+                      />
+                    )}
+                    {proposal.title.length > 0 ? proposal.title : proposal.id}
+                  </Link>
                 </DataCell>
                 <DataCell>
                   {daoStore.getCache().schemes[proposal.scheme].name}


### PR DESCRIPTION
Fixes #233.

This is surprisingly tough to fix. Our proposals list uses html `table` / `tr` / `td` tags. To make a whole row right-clickable as a link, we have to have an anchor tag in the row level, which seems to be impossible with HTML tables.

What I finally did was just making the proposal title a clickable link, which is not perfect as the table highlight and the proposal title highlight are two different things.

I think its better to move to a CSS table / flex / grid at some point anyway as HTML tables have their limits.