### PR TITLE
Feature/blockchainlink in header

### DIFF
--- a/src/components/Web3ConnectStatus/index.tsx
+++ b/src/components/Web3ConnectStatus/index.tsx
@@ -1,10 +1,10 @@
 import styled from 'styled-components';
 import { observer } from 'mobx-react';
-import { shortenAddress, toCamelCaseString } from '../../utils';
+import { toCamelCaseString } from '../../utils';
 import WalletModal from 'components/WalletModal';
 import { getChains, injected, isChainIdSupported } from 'provider/connectors';
 import { useContext } from '../../contexts';
-import { Box } from '../../components/common';
+import { Box, BlockchainLink } from '../../components/common';
 import NetworkModal from 'components/NetworkModal';
 import { useEffect, useState } from 'react';
 import { useRpcUrls } from 'provider/providerHooks';
@@ -109,7 +109,7 @@ const Web3ConnectStatus = observer(props => {
     } else if (account) {
       return (
         <AccountButton onClick={toggleWalletModal}>
-          {shortenAddress(account)}
+          <BlockchainLink text={account} />
         </AccountButton>
       );
     } else {

--- a/src/components/common/BlockchainLink.tsx
+++ b/src/components/common/BlockchainLink.tsx
@@ -51,7 +51,7 @@ export const BlockchainLink = ({
       setENSName(response);
     }
     getENS();
-  }, []);
+  }, [text]);
 
   let formatedAddress;
   if (!ensName && !dxVoteContract && !erc20Token) {


### PR DESCRIPTION
Adding blockchain link to header for clearer view of the connected account. 
Also added text to useEffect so ENS name refreshes when accounts are changed.

<img width="848" alt="スクリーンショット 2021-10-21 16 28 57" src="https://user-images.githubusercontent.com/39137239/138309681-aa601bc9-ff9e-4d98-8ebb-6a6f0b811b2b.png">
