### PR TITLE
fix: Prevent showing network data fetching errors after initial load.

### DIFF
--- a/src/stores/BlockchainStore.ts
+++ b/src/stores/BlockchainStore.ts
@@ -283,7 +283,9 @@ export default class BlockchainStore {
         this.activeFetchLoop = false;
       } catch (error) {
         console.error((error as Error).message);
-        notificationStore.setGlobalError(true, (error as Error).message);
+        if (!this.initialLoadComplete) {
+          notificationStore.setGlobalError(true, (error as Error).message);
+        }
         this.activeFetchLoop = false;
       }
     }


### PR DESCRIPTION
Fixes #294.

Funnily, I wasn't able to reproduce this now, although I accidentally ran into this earlier when I was working on something else. Anyway, adding this simple `initialLoadComplete` check should prevent the global error page from showing up when there's a data fetching issue after first load.