### PR TITLE
Refactor IPFS connectivity to handle initialization gracefully.

### DIFF
--- a/src/PageRouter.tsx
+++ b/src/PageRouter.tsx
@@ -42,7 +42,6 @@ const PageRouter = observer(({ children }) => {
       notificationStore,
       providerStore,
       configStore,
-      ipfsService,
       etherscanService,
       pinataService,
       coingeckoService,
@@ -55,7 +54,6 @@ const PageRouter = observer(({ children }) => {
   const networkName = configStore.getActiveChainName();
 
   // Start or auth services
-  ipfsService.start();
   etherscanService.isAuthenticated(networkName);
   pinataService.isAuthenticated();
 

--- a/src/services/IPFSService.ts
+++ b/src/services/IPFSService.ts
@@ -1,7 +1,8 @@
-import RootContext from '../contexts';
 import axios from 'axios';
 import IPFS from 'ipfs-core';
-const CID = require('cids');
+import CID from 'cids';
+import { sleep } from '../utils';
+import RootContext from '../contexts';
 
 export default class IPFSService {
   context: RootContext;
@@ -12,49 +13,59 @@ export default class IPFSService {
       fetched: Boolean;
     };
   } = {};
-  ipfs: any = null;
-  started: Boolean = false;
+  starting: Boolean = false;
+  private ipfs: IPFS.IPFS = null;
 
   constructor(context: RootContext) {
     this.context = context;
   }
 
-  async start() {
-    if (!this.ipfs && !this.started) {
-      this.started = true;
-      try {
-        this.ipfs = await IPFS.create();
-      } catch (error) {
-        console.error('[IPFS]', error);
-      }
+  async getIpfs(): Promise<IPFS.IPFS> {
+    if (this.starting) {
+      console.debug('[IPFS] IPFS is still starting. Sleeping for 5 seconds.');
+      await sleep(5000);
+      return this.getIpfs();
     }
+
+    if (!this.ipfs) {
+      console.debug('[IPFS] Initializing IPFS instance...');
+      await this.start();
+    }
+
+    console.debug('[IPFS] Reusing existing IPFS instance.');
+    return this.ipfs;
   }
 
-  async add(content: String) {
-    const { cid } = await this.ipfs.add({ content });
-    console.log(cid.string);
+  async add(content: string) {
+    const ipfs = await this.getIpfs();
+    const { cid } = await ipfs.add({ content });
+    console.debug(`[IPFS] Added content with CID ${cid.string}.`);
     return cid.string;
   }
 
-  async pin(hash: String) {
-    console.log(new CID(hash));
-    return await this.ipfs.pin.add(new CID(hash));
+  async pin(hash: string) {
+    const ipfs = await this.getIpfs();
+    const cid = new CID(hash);
+    console.debug('[IPFS] Pinning IPFS CID', cid);
+    return ipfs.pin.add(cid);
   }
 
-  async getContent(hash: String) {
+  async getContent(hash: string) {
     let content = [];
     try {
-      for await (const file of this.ipfs.get(hash)) {
-        console.debug('[IPFS FILE]', file.type, file.path);
-        if (!file.content) continue;
+      const ipfs = await this.getIpfs();
+
+      for await (const file of ipfs.get(hash)) {
+        console.debug('[IPFS] Getting content', file.type, file.path);
+        if (file.type != 'file' || !file.content) continue;
         for await (const chunk of file.content) {
           content = content.concat(chunk);
         }
       }
       return content.toString();
     } catch (e) {
-      console.error(e);
-      return 'error fetching IFPS';
+      console.error('[IPFS] Error getting content from IPFS', e);
+      return 'error getting content from IPFS';
     }
   }
 
@@ -65,5 +76,19 @@ export default class IPFSService {
         url: 'https://gateway.pinata.cloud/ipfs/' + hash,
       })
     ).data;
+  }
+
+  private async start() {
+    if (this.starting) return;
+
+    this.starting = true;
+    try {
+      this.ipfs = await IPFS.create();
+      console.debug('[IPFS] Initialized IPFS instance.');
+    } catch (e) {
+      console.error('[IPFS] Error initializing IPFS instance.', e);
+    } finally {
+      this.starting = false;
+    }
   }
 }

--- a/src/services/IPFSService.ts
+++ b/src/services/IPFSService.ts
@@ -5,7 +5,7 @@ import { sleep } from '../utils';
 import RootContext from '../contexts';
 
 export default class IPFSService {
-  private static SLEEP_MS = 5000;
+  private static SLEEP_MS = 1000;
 
   context: RootContext;
   starting: Boolean = false;
@@ -27,9 +27,10 @@ export default class IPFSService {
     if (!this.ipfs) {
       console.debug('[IPFS] Initializing IPFS instance...');
       await this.start();
+    } else {
+      console.debug('[IPFS] Reusing existing IPFS instance.');
     }
 
-    console.debug('[IPFS] Reusing existing IPFS instance.');
     return this.ipfs;
   }
 
@@ -62,7 +63,7 @@ export default class IPFSService {
       return content.toString();
     } catch (e) {
       console.error('[IPFS] Error getting content from IPFS', e);
-      return 'error getting content from IPFS';
+      return 'Error getting content from IPFS';
     }
   }
 

--- a/src/services/IPFSService.ts
+++ b/src/services/IPFSService.ts
@@ -5,14 +5,9 @@ import { sleep } from '../utils';
 import RootContext from '../contexts';
 
 export default class IPFSService {
+  private static SLEEP_MS = 5000;
+
   context: RootContext;
-  calls: {
-    [hash: string]: {
-      time: Number;
-      content: String;
-      fetched: Boolean;
-    };
-  } = {};
   starting: Boolean = false;
   private ipfs: IPFS.IPFS = null;
 
@@ -22,8 +17,10 @@ export default class IPFSService {
 
   async getIpfs(): Promise<IPFS.IPFS> {
     if (this.starting) {
-      console.debug('[IPFS] IPFS is still starting. Sleeping for 5 seconds.');
-      await sleep(5000);
+      console.debug(
+        `[IPFS] IPFS is still starting. Sleeping for ${IPFSService.SLEEP_MS}ms.`
+      );
+      await sleep(IPFSService.SLEEP_MS);
       return this.getIpfs();
     }
 


### PR DESCRIPTION
Previously, there was a race condition that prevented IPFS content from being loaded when the IPFS client still had not initialized. This PR refactors the `IPFSService` to handle connectivity more gracefully.

As a consequence of this change, we no longer need to initialize the IPFS client on application startup. Instead, it will be initialized only when needed.

Fixes #198.