### PR TITLE
Web3 Provider Refactor

### DIFF
--- a/src/components/WalletModal/index.tsx
+++ b/src/components/WalletModal/index.tsx
@@ -11,7 +11,8 @@ import Link from '../../components/common/Link';
 import { injected, getWallets } from 'provider/connectors';
 import { useContext } from '../../contexts';
 import { isChainIdSupported } from '../../provider/connectors';
-import { useActiveWeb3React, useRpcUrls } from 'provider/providerHooks';
+import { useRpcUrls } from 'provider/providerHooks';
+import { useWeb3React } from '@web3-react/core';
 
 const Wrapper = styled.div`
   ${({ theme }) => theme.flexColumnNoWrap}
@@ -99,7 +100,7 @@ const WalletModal = observer(() => {
     context: { modalStore },
   } = useContext();
   const { active, connector, error, activate, account, chainId } =
-    useActiveWeb3React();
+    useWeb3React();
   const rpcUrls = useRpcUrls();
   const [walletView, setWalletView] = useState(WALLET_VIEWS.ACCOUNT);
   const [connectionErrorMessage, setConnectionErrorMessage] = useState(false);

--- a/src/components/Web3ReactManager/index.tsx
+++ b/src/components/Web3ReactManager/index.tsx
@@ -16,6 +16,31 @@ import {
 import { useContext } from 'contexts';
 import { useInterval, usePrevious } from 'utils';
 
+const BlurWrapper = styled.div`
+  filter: blur(1px);
+`;
+
+const OverBlurModal = styled.div`
+  position: fixed;
+  z-index: 1;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  background-color: rgb(0, 0, 0);
+  background-color: rgba(0, 0, 0, 0.4);
+
+  .connectModalContent {
+    background-color: #fefefe;
+    max-width: 350px;
+    text-align: center;
+    margin: 15% auto;
+    padding: 20px;
+    border-radius: 4px;
+  }
+`;
+
 const BLOKCHAIN_FETCH_INTERVAL = 10000;
 
 const Web3ReactManager = ({ children }) => {
@@ -34,14 +59,16 @@ const Web3ReactManager = ({ children }) => {
     activate,
   } = web3Context;
 
-  providerStore.setWeb3Context(web3Context);
-
   console.debug('[Web3ReactManager] Start of render', {
-    injected: web3Context,
-    web3React: providerStore.getActiveWeb3React(),
+    web3Context,
   });
 
-  // try to eagerly connect to an injected provider, if it exists and has granted access already
+  // Make sure providerStore is synchronized with web3-react
+  useEffect(() => {
+    providerStore.setWeb3Context(web3Context);
+  }, [web3Context]);
+
+  // try to eagerly connect to a provider if possible
   const triedEager = useEagerConnect();
 
   useEffect(() => {
@@ -62,7 +89,7 @@ const Web3ReactManager = ({ children }) => {
     }
   }, [triedEager, networkActive, activate, rpcUrls]);
 
-  function switchChainAndReload(chainId) {
+  function switchChainAndReload(chainId: number) {
     const chains = getChains(rpcUrls);
     const chain = chains.find(chain => chain.id == chainId);
 
@@ -121,31 +148,6 @@ const Web3ReactManager = ({ children }) => {
     },
     networkActive ? BLOKCHAIN_FETCH_INTERVAL : 10
   );
-
-  const BlurWrapper = styled.div`
-    filter: blur(1px);
-  `;
-
-  const OverBlurModal = styled.div`
-    position: fixed;
-    z-index: 1;
-    left: 0;
-    top: 0;
-    width: 100%;
-    height: 100%;
-    overflow: auto;
-    background-color: rgb(0, 0, 0);
-    background-color: rgba(0, 0, 0, 0.4);
-
-    .connectModalContent {
-      background-color: #fefefe;
-      max-width: 350px;
-      text-align: center;
-      margin: 15% auto;
-      padding: 20px;
-      border-radius: 4px;
-    }
-  `;
 
   // on page load, do nothing until we've tried to connect to the injected connector
   if (!triedEager) {

--- a/src/components/Web3ReactManager/index.tsx
+++ b/src/components/Web3ReactManager/index.tsx
@@ -7,7 +7,6 @@ import {
   DEFAULT_ETH_CHAIN_ID,
   getChains,
   getNetworkConnector,
-  web3ContextNames,
 } from 'provider/connectors';
 import {
   useEagerConnect,
@@ -35,8 +34,7 @@ const Web3ReactManager = ({ children }) => {
     activate,
   } = web3Context;
 
-  if (!providerStore.activeChainId)
-    providerStore.setWeb3Context(web3ContextNames.default, web3Context);
+  providerStore.setWeb3Context(web3Context);
 
   console.debug('[Web3ReactManager] Start of render', {
     injected: web3Context,
@@ -82,7 +80,7 @@ const Web3ReactManager = ({ children }) => {
       // Handle the new chain.
       // Correctly handling chain changes can be complicated.
       // We recommend reloading the page unless you have good reason not to.
-      // providerStore.setWeb3Context(web3ContextNames.injected, web3ContextInjected);
+      // providerStore.setWeb3Context(web3ContextInjected);
       // blockchainStore.fetchData(providerStore.getActiveWeb3React(), true);
       switchChainAndReload(chainId);
     });

--- a/src/components/Web3ReactManager/index.tsx
+++ b/src/components/Web3ReactManager/index.tsx
@@ -29,21 +29,21 @@ const Web3ReactManager = ({ children }) => {
   const rpcUrls = useRpcUrls();
   const history = useHistory();
 
-  const web3ContextInjected = useWeb3React(web3ContextNames.injected);
+  const web3Context = useWeb3React();
   const {
     active: networkActive,
     error: networkError,
     chainId,
-  } = web3ContextInjected;
+  } = web3Context;
 
   if (!providerStore.activeChainId)
     providerStore.setWeb3Context(
-      web3ContextNames.injected,
-      web3ContextInjected
+      web3ContextNames.default,
+      web3Context
     );
 
   console.debug('[Web3ReactManager] Start of render', {
-    injected: web3ContextInjected,
+    injected: web3Context,
     web3React: providerStore.getActiveWeb3React(),
   });
 

--- a/src/components/Web3ReactManager/index.tsx
+++ b/src/components/Web3ReactManager/index.tsx
@@ -10,7 +10,6 @@ import {
   web3ContextNames,
 } from 'provider/connectors';
 import {
-  useActiveWeb3React,
   useEagerConnect,
   useInactiveListener,
   useRpcUrls,
@@ -25,7 +24,6 @@ const Web3ReactManager = ({ children }) => {
     context: { providerStore, blockchainStore, userStore },
   } = useContext();
   const location = useLocation();
-  const { activate } = useActiveWeb3React();
   const rpcUrls = useRpcUrls();
   const history = useHistory();
 
@@ -34,13 +32,11 @@ const Web3ReactManager = ({ children }) => {
     active: networkActive,
     error: networkError,
     chainId,
+    activate,
   } = web3Context;
 
   if (!providerStore.activeChainId)
-    providerStore.setWeb3Context(
-      web3ContextNames.default,
-      web3Context
-    );
+    providerStore.setWeb3Context(web3ContextNames.default, web3Context);
 
   console.debug('[Web3ReactManager] Start of render', {
     injected: web3Context,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,6 @@
 import ReactDOM from 'react-dom';
 import { HashRouter, Route, Switch, useLocation } from 'react-router-dom';
-import { createWeb3ReactRoot } from '@web3-react/core';
+import { Web3ReactProvider } from '@web3-react/core';
 import Web3ReactManager from 'components/Web3ReactManager';
 import Web3 from 'web3';
 import moment from 'moment';
@@ -9,8 +9,6 @@ import * as serviceWorker from './serviceWorker';
 
 import 'index.css';
 import ThemeProvider, { GlobalStyle } from './theme';
-
-import { web3ContextNames } from 'provider/connectors';
 
 import Header from './components/Header';
 import Footer from './components/Footer';
@@ -35,8 +33,6 @@ moment.updateLocale('en', {
     d: '1 day',
   },
 });
-
-const Web3ProviderInjected = createWeb3ReactRoot(web3ContextNames.injected);
 
 function getLibrary(provider) {
   return new Web3(provider);
@@ -97,7 +93,7 @@ const Routes = () => {
 };
 
 const Root = (
-  <Web3ProviderInjected getLibrary={getLibrary}>
+  <Web3ReactProvider getLibrary={getLibrary}>
     <ThemeProvider>
       <GlobalStyle />
       <HashRouter>
@@ -109,7 +105,7 @@ const Root = (
         </Switch>
       </HashRouter>
     </ThemeProvider>
-  </Web3ProviderInjected>
+  </Web3ReactProvider>
 );
 ReactDOM.render(Root, document.getElementById('root'));
 

--- a/src/pages/Configuration.tsx
+++ b/src/pages/Configuration.tsx
@@ -4,8 +4,8 @@ import { observer } from 'mobx-react';
 import { useContext } from '../contexts';
 import { FiCheckCircle, FiX } from 'react-icons/fi';
 import { Row, Box, Question, Button } from '../components/common';
-import { useActiveWeb3React } from 'provider/providerHooks';
 import { injected } from 'provider/connectors';
+import { useWeb3React } from '@web3-react/core';
 
 const FormLabel = styled.label`
   padding: 10px 0px;
@@ -56,7 +56,7 @@ const ConfigPage = observer(() => {
     },
   } = useContext();
   const networkName = configStore.getActiveChainName();
-  const { connector } = useActiveWeb3React();
+  const { connector } = useWeb3React();
 
   const [etherscanApiStatus, setEtherscanApiStatus] = React.useState(
     etherscanService.auth

--- a/src/provider/connectors.ts
+++ b/src/provider/connectors.ts
@@ -15,10 +15,6 @@ export const ACTIVE_NETWORKS = NETWORKS.filter(network =>
 export const ETH_NETWORKS_IDS = ACTIVE_NETWORKS.map(network => network.id);
 export const DEFAULT_ETH_CHAIN_ID = ACTIVE_NETWORKS[0].id;
 
-export const web3ContextNames = {
-  default: 'DEFAULT',
-};
-
 export const isChainIdSupported = (chainId: ChainConfig['id']): boolean => {
   return ETH_NETWORKS_IDS ? ETH_NETWORKS_IDS.indexOf(chainId) >= 0 : false;
 };

--- a/src/provider/connectors.ts
+++ b/src/provider/connectors.ts
@@ -16,8 +16,7 @@ export const ETH_NETWORKS_IDS = ACTIVE_NETWORKS.map(network => network.id);
 export const DEFAULT_ETH_CHAIN_ID = ACTIVE_NETWORKS[0].id;
 
 export const web3ContextNames = {
-  injected: 'INJECTED',
-  metamask: 'METAMASK',
+  default: 'DEFAULT',
 };
 
 export const isChainIdSupported = (chainId: ChainConfig['id']): boolean => {

--- a/src/provider/providerHooks.ts
+++ b/src/provider/providerHooks.ts
@@ -16,7 +16,6 @@ export function useEagerConnect() {
   const location = useLocation();
 
   useEffect(() => {
-    console.debug('[Injected Eager Connect]', injected);
     const chains = getChains();
     const urlNetworkName = location.pathname.split('/')[1];
     const urlChainId =
@@ -25,7 +24,8 @@ export function useEagerConnect() {
 
     const tryConnecting = async () => {
       const isAuthorized = await injected.isAuthorized();
-      console.debug('[Eager Connect] Activate injected if authorized', {
+      console.debug('[EagerConnect] Activate injected if authorized', {
+        injected,
         isAuthorized,
       });
 

--- a/src/provider/providerHooks.ts
+++ b/src/provider/providerHooks.ts
@@ -10,10 +10,6 @@ import { DEFAULT_RPC_URLS } from '../utils';
     If we're on mobile and have an injected connector, attempt even if not authorized (legacy support)
     If we tried to connect, or it's active, return true;
  */
-export function useActiveWeb3React() {
-  return useWeb3React();
-}
-
 export function useEagerConnect() {
   const { activate, active } = useWeb3React();
   const [tried, setTried] = useState(false);

--- a/src/provider/providerHooks.ts
+++ b/src/provider/providerHooks.ts
@@ -1,8 +1,8 @@
 import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
-import { useWeb3React as useWeb3ReactCore } from '@web3-react/core';
+import { useWeb3React } from '@web3-react/core';
 import { isMobile } from 'react-device-detect';
-import { getChains, injected, web3ContextNames } from '../provider/connectors';
+import { getChains, injected } from '../provider/connectors';
 import { useContext } from '../contexts';
 import { DEFAULT_RPC_URLS } from '../utils';
 
@@ -11,11 +11,11 @@ import { DEFAULT_RPC_URLS } from '../utils';
     If we tried to connect, or it's active, return true;
  */
 export function useActiveWeb3React() {
-  return useWeb3ReactCore(web3ContextNames.injected);
+  return useWeb3React();
 }
 
 export function useEagerConnect() {
-  const { activate, active } = useWeb3ReactCore(web3ContextNames.injected);
+  const { activate, active } = useWeb3React();
   const [tried, setTried] = useState(false);
   const location = useLocation();
 
@@ -79,9 +79,7 @@ export function useEagerConnect() {
  * and out after checking what network they're on
  */
 export function useInactiveListener(suppress = false) {
-  const { active, error, activate } = useWeb3ReactCore(
-    web3ContextNames.injected
-  );
+  const { active, error, activate } = useWeb3React();
 
   useEffect(() => {
     const { ethereum } = window;

--- a/src/stores/Provider.ts
+++ b/src/stores/Provider.ts
@@ -149,7 +149,7 @@ export default class ProviderStore {
   }
 
   getActiveWeb3React(): Web3ReactContextInterface {
-    const contextInjected = this.web3Contexts[web3ContextNames.injected];
+    const contextInjected = this.web3Contexts[web3ContextNames.default];
     return contextInjected;
   }
 

--- a/src/stores/Provider.ts
+++ b/src/stores/Provider.ts
@@ -41,7 +41,7 @@ export default class ProviderStore {
     this.context = context;
     this.web3Context = null;
     this.chainData = { currentBlockNumber: -1 };
-    
+
     makeObservable(this, {
       web3Context: observable,
       chainData: observable,
@@ -57,6 +57,7 @@ export default class ProviderStore {
   }
 
   setCurrentBlockNumber(blockNumber: number): void {
+    console.debug('[ProviderStore] Setting current block number', blockNumber);
     this.chainData.currentBlockNumber = blockNumber;
   }
 
@@ -82,7 +83,7 @@ export default class ProviderStore {
   }
 
   setWeb3Context(context: Web3ReactContextInterface) {
-    console.debug('[setWeb3Context]', context);
+    console.debug('[ProviderStore] Setting Web3 context', context);
     this.web3Context = context;
   }
 


### PR DESCRIPTION
This is a cleanup of the code around Web3 provider management.

- Simplifies Web3 provider handling by removing code to handle multiple Web3 contexts. (We were using only one, and we should be able to handle our use cases without having multiple Web3 contexts at the global level.)
- Cleans up `ProviderStore` by removing unused code.

This is part of a larger change to have a cleaner web3 implementation. I'll be submitting these changes as multiple PRs as its easier to review.