### PR TITLE
Fixing blockchain link in history

### DIFF
--- a/src/components/common/BlockchainLink.tsx
+++ b/src/components/common/BlockchainLink.tsx
@@ -6,6 +6,7 @@ import {
   getERC20Token,
   getDxVoteContract,
   toAddressStub,
+  isAddress,
 } from 'utils';
 import { useContext } from '../../contexts';
 import { FiExternalLink } from 'react-icons/fi';
@@ -69,7 +70,11 @@ export const BlockchainLink = ({
   return (
     <AddressLink>
       <a
-        href={getBlockchainLink(text, networkName, type)}
+        href={getBlockchainLink(
+          text,
+          networkName,
+          isAddress(text) ? 'address' : type
+        )}
         target="_blank"
         rel="noreferrer"
       >

--- a/src/pages/Proposal.tsx
+++ b/src/pages/Proposal.tsx
@@ -451,7 +451,7 @@ const ProposalPage = observer(() => {
         components.push(<span>{phrase}</span>);
         if (textParams[key])
           components.push(
-            <BlockchainLink text={textParams} toCopy={false} size="short" />
+            <BlockchainLink text={textParams[0]} toCopy={false} size="short" />
           );
         return components;
       });


### PR DESCRIPTION
Identified by Sky there is an issue with links  in the history section.
I found the reason was because the type of link was not being checked and when it was there was an issue because it was an array.
Links should work now on both transactions and addresses in history section. 

A side benefit is now that ens names are resolved in history.

Fixes #323 