### PR TITLE
fix: Tracking abis properly per file and getting local controller abi

### DIFF
--- a/src/components/CallDataInformation.tsx
+++ b/src/components/CallDataInformation.tsx
@@ -48,7 +48,6 @@ const CallDataInformation = observer(
         proposal.to.map(item => getContractABI(item))
       );
       result.map((abi, i) => {
-        console.log({ abi });
         proposalCallArray.push(
           decodedCallData(
             scheme.type === 'WalletScheme' &&
@@ -62,7 +61,6 @@ const CallDataInformation = observer(
           )
         );
       });
-      console.log({ proposalCallArray });
       setLoading(false);
     };
     useEffect(() => {
@@ -165,7 +163,6 @@ const CallDataInformation = observer(
       );
     };
     const etherscanCallDisplay = (to: string, from: string, abi: any) => {
-      console.log({ to, from, abi });
       if (advancedCalls) {
         return (
           <div>
@@ -281,7 +278,6 @@ const CallDataInformation = observer(
             },
             i
           ) => {
-            console.log({ contractABI });
             return (
               <div>
                 {i > 0 ? <Divider></Divider> : null}

--- a/src/components/CallDataInformation.tsx
+++ b/src/components/CallDataInformation.tsx
@@ -165,6 +165,7 @@ const CallDataInformation = observer(
       );
     };
     const etherscanCallDisplay = (to: string, from: string, abi: any) => {
+      console.log({ to, from, abi });
       if (advancedCalls) {
         return (
           <div>
@@ -182,7 +183,7 @@ const CallDataInformation = observer(
             </p>
             <p>
               <strong>Function: </strong>
-              <small>{abi.function.signature}</small>
+              <small>{abi?.function?.signature}</small>
             </p>
             {Object.keys(abi.args)
               .filter(item => item != '__length__')
@@ -210,7 +211,7 @@ const CallDataInformation = observer(
           </div>
         );
       }
-      return decodedText(from, to, abi.function.signature);
+      return decodedText(from, to, abi?.function?.signature);
     };
 
     const errorDisplay = (error: Error) => {
@@ -296,7 +297,7 @@ const CallDataInformation = observer(
                       value,
                       contractABI,
                     })
-                  : contractABI
+                  : contractABI.function
                   ? etherscanCallDisplay(to, from, contractABI)
                   : baseDisplay(to, from, data, value, advancedCalls)}
               </div>

--- a/src/hooks/useABIService.ts
+++ b/src/hooks/useABIService.ts
@@ -48,8 +48,10 @@ export const useABIService = (): UseABIServiceReturns => {
     try {
       const abi = abiService.decodeCall(data, contract, contractABI);
       setABI(abi);
+      return abi;
     } catch (error) {
       console.log(error);
+      return {};
     }
   };
 
@@ -58,7 +60,7 @@ export const useABIService = (): UseABIServiceReturns => {
     to: string,
     data: string,
     value: BigNumber,
-    contractABI: any
+    contractABI: string
   ) => {
     const { library } = providerStore.getActiveWeb3React();
     const recommendedCalls = configStore.getRecommendedCalls();
@@ -68,7 +70,7 @@ export const useABIService = (): UseABIServiceReturns => {
       data,
       ContractType.Controller
     );
-    decodeABI({ data, contractABI });
+    const decodedAbi = decodeABI({ data, contractABI });
 
     if (
       controllerCallDecoded &&
@@ -120,6 +122,7 @@ export const useABIService = (): UseABIServiceReturns => {
         callParameters: callParameters,
         data: data,
         value: value,
+        contractABI: decodedAbi,
       };
     }
 
@@ -129,6 +132,7 @@ export const useABIService = (): UseABIServiceReturns => {
       data: data,
       value: value,
       functionSignature: functionSignature,
+      contractABI: decodedAbi,
     };
   };
 

--- a/src/hooks/useEtherscanService.ts
+++ b/src/hooks/useEtherscanService.ts
@@ -28,6 +28,7 @@ export const useEtherscanService = (): UseEtherscanServiceReturns => {
   } = useContext();
 
   const networkName = configStore.getActiveChainName();
+  const contracts = configStore.getNetworkContracts();
 
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<Error | null>(null);
@@ -47,6 +48,11 @@ export const useEtherscanService = (): UseEtherscanServiceReturns => {
   const getContractABI = async (address: string) => {
     try {
       setLoading(true);
+
+      if (address === contracts.controller) {
+        return JSON.stringify(require('../contracts/DxController.json').abi);
+      }
+
       const ABI = await etherscanService.getContractABI(address, networkName);
       checkEtherscanErrors(ABI);
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -369,6 +369,7 @@ export interface ProposalCalls {
   recommendedCallUsed?: RecommendedCallUsed | undefined;
   callParameters?: unknown | undefined;
   encodedFunctionName?: string | undefined;
+  contractABI: any;
 }
 
 export interface RecommendedCallUsed {


### PR DESCRIPTION
Fixing duplicate call data appearing on more complex wallet scheme proposals.

Issues fixed:
- Controller was not verified so ABI was not found - Added check for the controller and pulling ABI locally if matched
- ABI value was storing single value  - Storing ABI in decoded calls object instead which is in an array

Closes #302 