### PR TITLE
Improve DAOtalk importer UX.

### DIFF
--- a/src/components/DiscourseImporter/index.tsx
+++ b/src/components/DiscourseImporter/index.tsx
@@ -67,7 +67,7 @@ const DiscourseImporter: React.FC<DiscourseImporterProps> = ({ onImport }) => {
 
   const getTopic = async (topicId: number) => {
     const response = await fetch(
-      `https://cors-anywhere.herokuapp.com/${DISCOURSE_URL_ROOT}/t/${topicId}.json`,
+      `${DISCOURSE_URL_ROOT}/t/${topicId}.json`,
       {
         headers: { 'content-type': 'application/json' },
       }
@@ -83,7 +83,7 @@ const DiscourseImporter: React.FC<DiscourseImporterProps> = ({ onImport }) => {
 
   const getPost = async (postId: number) => {
     const response = await fetch(
-      `https://cors-anywhere.herokuapp.com/${DISCOURSE_URL_ROOT}/posts/${postId}.json`,
+      `${DISCOURSE_URL_ROOT}/posts/${postId}.json`,
       {
         headers: { 'content-type': 'application/json' },
       }

--- a/src/components/DiscourseImporter/index.tsx
+++ b/src/components/DiscourseImporter/index.tsx
@@ -26,15 +26,21 @@ const LinkInput = styled.input`
   padding: 0px 5px;
 `;
 
+const ErrorMessage = styled.span`
+  font-size: 0.8rem;
+  color: red;
+`;
 interface DiscourseImporterProps {
   onImport: (importedMarkdown: string) => void;
 }
 
 const DiscourseImporter: React.FC<DiscourseImporterProps> = ({ onImport }) => {
   const [discourseLink, setDiscourseLink] = useState('');
+  const [isImporting, setIsImporting] = useState(false);
   const [isInvalid, setIsInvalid] = useState<boolean>(false);
+  const [errorMessage, setErrorMessage] = useState<string>(null);
 
-  const parseDiscourseUrlTopicId = (urlString: string) => {
+  const parseDiscourseUrlTopicId = (urlString: string): number | null => {
     if (urlString.startsWith(DISCOURSE_URL_ROOT)) {
       // Try to parse the string as a URL
       try {
@@ -44,8 +50,7 @@ const DiscourseImporter: React.FC<DiscourseImporterProps> = ({ onImport }) => {
         // Extract topicId from a topic URL
         if (path.startsWith('/t')) {
           const topicId = Number.parseInt(path.split('/')[3]);
-          console.log('[DiscourseImporter] Found topic ID', topicId);
-          setIsInvalid(false);
+          console.info('[DiscourseImporter] Found topic ID', topicId);
           return topicId;
         }
       } catch (e) {
@@ -57,52 +62,82 @@ const DiscourseImporter: React.FC<DiscourseImporterProps> = ({ onImport }) => {
     }
 
     console.warn('[DiscourseImporter] Incorrect URL entered.');
-    setIsInvalid(true);
     return null;
   };
 
   const getTopic = async (topicId: number) => {
-    const response = await fetch(`${DISCOURSE_URL_ROOT}/t/${topicId}.json`, {
-      headers: { 'content-type': 'application/json' },
-    });
-    const result = await response.json();
-
-    return result;
+    const response = await fetch(
+      `https://cors-anywhere.herokuapp.com/${DISCOURSE_URL_ROOT}/t/${topicId}.json`,
+      {
+        headers: { 'content-type': 'application/json' },
+      }
+    );
+    if (response.ok) {
+      const result = await response.json();
+      return result;
+    } else {
+      console.error('[DiscourseImporter] Error while obtaining topic.');
+      throw new Error('Unable to get topic.');
+    }
   };
 
   const getPost = async (postId: number) => {
-    const response = await fetch(`${DISCOURSE_URL_ROOT}/posts/${postId}.json`, {
-      headers: { 'content-type': 'application/json' },
-    });
-    const result = await response.json();
-
-    return result;
+    const response = await fetch(
+      `https://cors-anywhere.herokuapp.com/${DISCOURSE_URL_ROOT}/posts/${postId}.json`,
+      {
+        headers: { 'content-type': 'application/json' },
+      }
+    );
+    if (response.ok) {
+      const result = await response.json();
+      return result;
+    } else {
+      console.error('[DiscourseImporter] Error while obtaining post content.');
+      throw new Error('Unable to get post content.');
+    }
   };
 
   const processImport = async () => {
+    setIsImporting(true);
     const topicId = parseDiscourseUrlTopicId(discourseLink);
-    if (!topicId) return;
+    if (!topicId) {
+      setIsInvalid(true);
+      setErrorMessage('Incorrect URL. Please recheck.');
+      setIsImporting(false);
+      return;
+    }
 
-    const topic = await getTopic(topicId);
-    const post = await getPost(topic.post_stream.stream[0]);
-    onImport(post.raw);
+    try {
+      const topic = await getTopic(topicId);
+      const post = await getPost(topic.post_stream.stream[0]);
+      onImport(post.raw);
+    } catch (e) {
+      setIsInvalid(true);
+      setErrorMessage(e?.message);
+    } finally {
+      setIsImporting(false);
+    }
   };
 
   return (
     <Container>
-      <LinkLabel htmlFor="link-input">Enter forum post URL</LinkLabel>
+      <LinkLabel htmlFor="link-input">Enter DAOtalk forum post URL</LinkLabel>
       <InputRow>
         <LinkInput
           name="link-input"
           value={discourseLink}
           onChange={e => {
             setIsInvalid(false);
+            setErrorMessage(null);
             setDiscourseLink(e.target.value);
           }}
           invalid={isInvalid}
         />
-        <Button onClick={processImport}>Import</Button>
+        <Button onClick={processImport} disabled={isImporting}>
+          {isImporting ? 'Importing...' : 'Import'}
+        </Button>
       </InputRow>
+      <ErrorMessage>{errorMessage}</ErrorMessage>
     </Container>
   );
 };

--- a/src/components/DiscourseImporter/index.tsx
+++ b/src/components/DiscourseImporter/index.tsx
@@ -111,6 +111,8 @@ const DiscourseImporter: React.FC<DiscourseImporterProps> = ({ onImport }) => {
       const topic = await getTopic(topicId);
       const post = await getPost(topic.post_stream.stream[0]);
       onImport(post.raw);
+      setIsInvalid(false);
+      setErrorMessage(null);
     } catch (e) {
       setIsInvalid(true);
       setErrorMessage(e?.message);

--- a/src/pages/Metadata.tsx
+++ b/src/pages/Metadata.tsx
@@ -8,6 +8,7 @@ import MDEditor, { commands } from '@uiw/react-md-editor';
 import { useContext } from '../contexts';
 import { Button } from '../components/common/Button';
 import { Box } from '../components/common';
+import DiscourseImporter from '../components/DiscourseImporter';
 
 const ProposalsWrapper = styled.div`
   padding: 10px 0px;
@@ -39,6 +40,7 @@ const ButtonsWrapper = styled.div`
   width: 100%;
   flex-wrap: wrap;
   justify-content: space-around;
+  margin-top: 100px;
 `;
 
 const MarkdownWrapper = styled.div`
@@ -140,16 +142,20 @@ export const CreateMetadataPage = observer(() => {
               value={title}
             />
             {error}
-            <ButtonsWrapper>
-              <Button onClick={() => history.push(`../type`)}>Back</Button>
-              <Button
-                onClick={async () => {
-                  await uploadToIPFS();
-                }}
-              >
-                Next
-              </Button>
-            </ButtonsWrapper>
+
+            <div>
+              <DiscourseImporter onImport={onDescriptionChange} />
+              <ButtonsWrapper>
+                <Button onClick={() => history.push(`../type`)}>Back</Button>
+                <Button
+                  onClick={async () => {
+                    await uploadToIPFS();
+                  }}
+                >
+                  Next
+                </Button>
+              </ButtonsWrapper>
+            </div>
           </SidebarWrapper>
           <MarkdownWrapper>
             <Editor


### PR DESCRIPTION
This PR adds validations, error messages and loading statuses to the Discourse post importer in the proposal creation UI. The importer has also been added to the new Metadata editor in the new proposal creation flow.

![image](https://user-images.githubusercontent.com/25136207/140372235-25ba255e-2ec1-45cf-9b9f-87285b26021b.png)

There are some caveats to this component right now.
1. Images uploaded to DAOtalk won't show up, and will appear broken. (Discourse has a special format for image uploads that looks like `upload://<id>.jpeg`.)
2. This will only import the original post of a thread. There are cases where people post the second payment proposal of a contributor proposal in the same thread, with a retrospective. This doesn't support importing such posts right now.