### PR TITLE
Fix/contributor bugs

### DIFF
--- a/src/pages/ProposalSubmission/ContributorProposal.tsx
+++ b/src/pages/ProposalSubmission/ContributorProposal.tsx
@@ -265,49 +265,7 @@ export const ContributorProposalPage = observer(() => {
         account,
         contracts.avatar
       );
-      console.log('encoding stable call');
-      console.log({
-        stables: levels[selectedLevel]?.stable,
-        discount,
-        stableOverride,
-      });
-      console.log(
-        calculateDiscountedValue(
-          levels[selectedLevel]?.stable,
-          discount,
-          stableOverride
-        )
-      );
-      console.log(
-        calculateDiscountedValue(
-          levels[selectedLevel]?.stable,
-          discount,
-          stableOverride
-        ).toString()
-      );
-      console.log('bnum');
-      console.log(
-        bnum(
-          calculateDiscountedValue(
-            levels[selectedLevel]?.stable,
-            discount,
-            stableOverride
-          )
-        )
-      );
-      console.log('denorm');
-      console.log(
-        denormalizeBalance(
-          bnum(
-            calculateDiscountedValue(
-              levels[selectedLevel]?.stable,
-              discount,
-              stableOverride
-            )
-          )
-        ).toString()
-      );
-      console.log('done');
+
       // Encode WXDAI transfer
       const wxdaiTransferCallData = encodeErc20Transfer(
         library,

--- a/src/pages/ProposalSubmission/ContributorProposal.tsx
+++ b/src/pages/ProposalSubmission/ContributorProposal.tsx
@@ -305,7 +305,7 @@ export const ContributorProposalPage = observer(() => {
               stableOverride
             )
           )
-        )
+        ).toString()
       );
       console.log('done');
       // Encode WXDAI transfer
@@ -320,7 +320,7 @@ export const ContributorProposalPage = observer(() => {
               stableOverride
             )
           )
-        )
+        ).toString()
       );
 
       // Encode DXD approval

--- a/src/pages/ProposalSubmission/ContributorProposal.tsx
+++ b/src/pages/ProposalSubmission/ContributorProposal.tsx
@@ -265,7 +265,49 @@ export const ContributorProposalPage = observer(() => {
         account,
         contracts.avatar
       );
-
+      console.log('encoding stable call');
+      console.log({
+        stables: levels[selectedLevel]?.stable,
+        discount,
+        stableOverride,
+      });
+      console.log(
+        calculateDiscountedValue(
+          levels[selectedLevel]?.stable,
+          discount,
+          stableOverride
+        )
+      );
+      console.log(
+        calculateDiscountedValue(
+          levels[selectedLevel]?.stable,
+          discount,
+          stableOverride
+        ).toString()
+      );
+      console.log('bnum');
+      console.log(
+        bnum(
+          calculateDiscountedValue(
+            levels[selectedLevel]?.stable,
+            discount,
+            stableOverride
+          )
+        )
+      );
+      console.log('denorm');
+      console.log(
+        denormalizeBalance(
+          bnum(
+            calculateDiscountedValue(
+              levels[selectedLevel]?.stable,
+              discount,
+              stableOverride
+            )
+          )
+        )
+      );
+      console.log('done');
       // Encode WXDAI transfer
       const wxdaiTransferCallData = encodeErc20Transfer(
         library,

--- a/src/pages/ProposalSubmission/ContributorProposal.tsx
+++ b/src/pages/ProposalSubmission/ContributorProposal.tsx
@@ -219,9 +219,7 @@ export const ContributorProposalPage = observer(() => {
 
   // Reset stable override when changing level
   useEffect(() => {
-    setStableOverride(
-      calculateDiscountedValue(levels[selectedLevel]?.stable, discount)
-    );
+    setStableOverride(null);
   }, [selectedLevel]);
 
   const calculateDiscountedValue = (amount, discount, override = null) => {

--- a/src/pages/ProposalSubmission/ContributorProposal.tsx
+++ b/src/pages/ProposalSubmission/ContributorProposal.tsx
@@ -423,7 +423,13 @@ export const ContributorProposalPage = observer(() => {
     <VerticalLayout>
       <NavigationBar>
         <BackToProposals
-          onClick={() => history.push('../metadata/contributor')}
+          onClick={() => {
+            if (advanced) {
+              setAdvanced(false);
+            } else {
+              history.push('../metadata/contributor');
+            }
+          }}
         >
           {`< Back`}
         </BackToProposals>


### PR DESCRIPTION
Fix stable override issue where adjusting percent worked would not change the actual value due to automatic stable override
Instead override now defaults to null 

Also updated back button to go out of advanced options instead of straight back to metadata creation if in advanced options screen.

Using this to test strange big number error that only shows up in deployed versions of the code also 
Issue turned out to be encoding a big number and not a string from the start - but no clue why it worked locally and not when deployed, very weird

No hotfix needed - can wait until 1.0.4