### PR TITLE
Feature/blockchainlink component updates

### DIFF
--- a/src/components/Web3ConnectStatus/index.tsx
+++ b/src/components/Web3ConnectStatus/index.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import { observer } from 'mobx-react';
-import { toAddressStub, toCamelCaseString } from '../../utils';
+import { toCamelCaseString } from '../../utils';
 import WalletModal from 'components/WalletModal';
 import { getChains, injected, isChainIdSupported } from 'provider/connectors';
 import { useContext } from '../../contexts';
@@ -8,6 +8,7 @@ import { Box } from '../../components/common';
 import NetworkModal from 'components/NetworkModal';
 import { useEffect, useState } from 'react';
 import { useRpcUrls } from 'provider/providerHooks';
+import BlockchainLink from '../common/BlockchainLink';
 
 const WrongNetworkButton = styled(Box)`
   color: var(--dark-text-gray);
@@ -109,7 +110,7 @@ const Web3ConnectStatus = observer(props => {
     } else if (account) {
       return (
         <AccountButton onClick={toggleWalletModal}>
-          {toAddressStub(account)}
+          <BlockchainLink text={account} onlyText />
         </AccountButton>
       );
     } else {

--- a/src/components/common/BlockchainLink.tsx
+++ b/src/components/common/BlockchainLink.tsx
@@ -2,7 +2,6 @@ import styled from 'styled-components';
 import Copy from './Copy';
 import {
   getBlockchainLink,
-  getENSName,
   getERC20Token,
   getDxVoteContract,
   toAddressStub,
@@ -39,7 +38,7 @@ export const BlockchainLink = ({
   onlyText = false,
 }) => {
   const {
-    context: { configStore },
+    context: { configStore, ensService },
   } = useContext();
 
   const networkName = configStore.getActiveChainName();
@@ -49,7 +48,7 @@ export const BlockchainLink = ({
 
   useEffect(() => {
     async function getENS() {
-      const response = await getENSName(text);
+      const response = await ensService.resolveENSName(text);
       setENSName(response);
     }
     getENS();

--- a/src/components/common/BlockchainLink.tsx
+++ b/src/components/common/BlockchainLink.tsx
@@ -36,6 +36,7 @@ export const BlockchainLink = ({
   type = 'default',
   toCopy = false,
   onlyIcon = false,
+  onlyText = false,
 }) => {
   const {
     context: { configStore },
@@ -66,24 +67,35 @@ export const BlockchainLink = ({
   If the address is an known dxvote contract (avatar,controller, etc) domain show the contract name with a link to the blockchain explorer address and option to copy the address.
   else show formatted address
   */
+  const Address = () => (
+    <>
+      {ensName}
+      {!ensName && erc20Token && <Icon src={erc20Token.logoURI} />}
+      {!ensName && dxVoteContract && dxVoteContract?.contract}
+      {formatedAddress}
+    </>
+  );
 
   return (
     <AddressLink>
-      <a
-        href={getBlockchainLink(
-          text,
-          networkName,
-          isAddress(text) ? 'address' : type
-        )}
-        target="_blank"
-        rel="noreferrer"
-      >
-        {ensName}
-        {!ensName && erc20Token && <Icon src={erc20Token.logoURI} />}
-        {!ensName && dxVoteContract && dxVoteContract?.contract}
-        {formatedAddress}
-      </a>
-      {toCopy ? <Copy toCopy={text} /> : <div />}
+      {!onlyText ? (
+        <a
+          href={getBlockchainLink(
+            text,
+            networkName,
+            isAddress(text) ? 'address' : type
+          )}
+          target="_blank"
+          rel="noreferrer"
+        >
+          <Address />
+        </a>
+      ) : (
+        <div>
+          <Address />
+        </div>
+      )}
+      {toCopy ? <Copy toCopy={text} /> : null}
     </AddressLink>
   );
 };

--- a/src/pages/Configuration.tsx
+++ b/src/pages/Configuration.tsx
@@ -4,8 +4,6 @@ import { observer } from 'mobx-react';
 import { useContext } from '../contexts';
 import { FiCheckCircle, FiX } from 'react-icons/fi';
 import { Row, Box, Question, Button } from '../components/common';
-import { injected } from 'provider/connectors';
-import { useWeb3React } from '@web3-react/core';
 
 const FormLabel = styled.label`
   padding: 10px 0px;
@@ -56,7 +54,6 @@ const ConfigPage = observer(() => {
     },
   } = useContext();
   const networkName = configStore.getActiveChainName();
-  const { connector } = useWeb3React();
 
   const [etherscanApiStatus, setEtherscanApiStatus] = React.useState(
     etherscanService.auth
@@ -144,72 +141,68 @@ const ConfigPage = observer(() => {
           <FormLabel>{pinataKeyStatus ? <FiCheckCircle /> : <FiX />}</FormLabel>
         </Row>
 
-        {connector != injected && (
-          <>
-            <Row>
-              <FormLabel>RPC:</FormLabel>
-              <Dropdown
-                onChange={event =>
-                  onApiKeyValueChange(event.target.value, 'rpcType')
-                }
-                value={localConfig.rpcType}
-              >
-                <option value="">Default</option>
-                <option value="infura">Infura</option>
-                <option value="alchemy">Alchemy</option>
-                <option value="custom">Custom</option>
-              </Dropdown>
-            </Row>
+        <Row>
+          <FormLabel>RPC:</FormLabel>
+          <Dropdown
+            onChange={event =>
+              onApiKeyValueChange(event.target.value, 'rpcType')
+            }
+            value={localConfig.rpcType}
+          >
+            <option value="">Default</option>
+            <option value="infura">Infura</option>
+            <option value="alchemy">Alchemy</option>
+            <option value="custom">Custom</option>
+          </Dropdown>
+        </Row>
 
-            {localConfig.rpcType === 'infura' && (
-              <Row>
-                <FormLabel>Infura:</FormLabel>
-                <InputBox
-                  type="text"
-                  serviceName="infura"
-                  onChange={event =>
-                    onApiKeyValueChange(event.target.value, 'infura')
-                  }
-                  value={localConfig.infura}
-                ></InputBox>
-                <FormLabel>
-                  {infuraKeyStatus ? <FiCheckCircle /> : <FiX />}
-                </FormLabel>
-              </Row>
-            )}
-            {localConfig.rpcType === 'alchemy' && (
-              <Row>
-                <FormLabel>Alchemy:</FormLabel>
-                <InputBox
-                  type="text"
-                  serviceName="alchemy"
-                  onChange={event =>
-                    onApiKeyValueChange(event.target.value, 'alchemy')
-                  }
-                  value={localConfig.alchemy}
-                ></InputBox>
-                <FormLabel>
-                  {alchemyKeyStatus ? <FiCheckCircle /> : <FiX />}
-                </FormLabel>
-              </Row>
-            )}
-            {localConfig.rpcType === 'custom' && (
-              <Row>
-                <FormLabel>RPC URL:</FormLabel>
-                <InputBox
-                  type="text"
-                  serviceName="customRpcUrl"
-                  onChange={event =>
-                    onApiKeyValueChange(event.target.value, 'customRpcUrl')
-                  }
-                  value={localConfig.customRpcUrl}
-                ></InputBox>
-                <FormLabel>
-                  {customRpcUrlStatus ? <FiCheckCircle /> : <FiX />}
-                </FormLabel>
-              </Row>
-            )}
-          </>
+        {localConfig.rpcType === 'infura' && (
+          <Row>
+            <FormLabel>Infura:</FormLabel>
+            <InputBox
+              type="text"
+              serviceName="infura"
+              onChange={event =>
+                onApiKeyValueChange(event.target.value, 'infura')
+              }
+              value={localConfig.infura}
+            ></InputBox>
+            <FormLabel>
+              {infuraKeyStatus ? <FiCheckCircle /> : <FiX />}
+            </FormLabel>
+          </Row>
+        )}
+        {localConfig.rpcType === 'alchemy' && (
+          <Row>
+            <FormLabel>Alchemy:</FormLabel>
+            <InputBox
+              type="text"
+              serviceName="alchemy"
+              onChange={event =>
+                onApiKeyValueChange(event.target.value, 'alchemy')
+              }
+              value={localConfig.alchemy}
+            ></InputBox>
+            <FormLabel>
+              {alchemyKeyStatus ? <FiCheckCircle /> : <FiX />}
+            </FormLabel>
+          </Row>
+        )}
+        {localConfig.rpcType === 'custom' && (
+          <Row>
+            <FormLabel>RPC URL:</FormLabel>
+            <InputBox
+              type="text"
+              serviceName="customRpcUrl"
+              onChange={event =>
+                onApiKeyValueChange(event.target.value, 'customRpcUrl')
+              }
+              value={localConfig.customRpcUrl}
+            ></InputBox>
+            <FormLabel>
+              {customRpcUrlStatus ? <FiCheckCircle /> : <FiX />}
+            </FormLabel>
+          </Row>
         )}
       </FormContainer>
       <Row>

--- a/src/services/ENSService.ts
+++ b/src/services/ENSService.ts
@@ -1,7 +1,7 @@
 import { Web3ReactContextInterface } from '@web3-react/core/dist/types';
-import RootContext from '../contexts';
 import { namehash, labelhash } from '@ensdomains/ensjs';
-
+import { ethers } from 'ethers';
+import RootContext from '../contexts';
 export default class ENSService {
   context: RootContext;
   web3Context: Web3ReactContextInterface;
@@ -18,6 +18,21 @@ export default class ENSService {
   setENSWeb3Context(context: Web3ReactContextInterface) {
     console.debug('[ENSService] Setting Mainnet Web3 context', context);
     this.web3Context = context;
+  }
+
+  async resolveENSName(address: string) {
+    let name = null;
+    try {
+      const web3 = this.web3Context.library;
+      const provider = new ethers.providers.Web3Provider(web3.currentProvider);
+      const checksumed = ethers.utils.getAddress(address);
+      name = await provider.lookupAddress(checksumed);
+    } catch (e) {
+      console.warn(
+        '[ENSService] Error while trying to reverse resolve ENS address.'
+      );
+    }
+    return name;
   }
 
   async resolveContentHash(ensAddress: string): Promise<string | null> {

--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -63,18 +63,6 @@ export function getBlockchainLink(address, networkName, type) {
   }
 }
 
-export async function getENSName(address) {
-  let name = null;
-  try {
-    const provider = ethers.getDefaultProvider();
-    const checksumed = ethers.utils.getAddress(address);
-    name = provider.lookupAddress(checksumed);
-  } catch (e) {
-    console.error(e);
-  }
-  return name;
-}
-
 export function getERC20Token(address) {
   let tokenObject;
   Object.entries(appConfig).forEach(([_, value]) => {


### PR DESCRIPTION
This has a few refactors and bugfixes regarding the `BlockchainLink` component and ENS reverse resolution.

1. `BlockchainLink` component now has a `onlyText` prop, which enables to show just the resolved ENS name / wallet address, without the linking to the block explorer.
2. `BlockchainLink` has been added back to the application header, which fixes #355.
3. ENS reverse resolution has been moved to `ENSService`. Now this reuses the same `MainnetWeb3Provider` Web3 connection, without spawning a new one with ethers.js default settings.
4. ENS resolution errors now only throw a warning instead of an error.
5. `MainnetWeb3Provider` uses the RPC configs even when MetaMask is connected. The RPC configuration UI is now shown even when MetaMask is connected.