### PR TITLE
feat: Adding date input to contributor proposal

### DIFF
--- a/src/components/common/Forms/InputDate.tsx
+++ b/src/components/common/Forms/InputDate.tsx
@@ -26,7 +26,8 @@ const Date = styled(Datetime)`
     width: ${props => `${props.width}px`};
   }
   .rdtPicker {
-    width: 100%;
+    left: 50%;
+    transform: translateX(-50%);
   }
 `;
 

--- a/src/components/common/Forms/InputDate.tsx
+++ b/src/components/common/Forms/InputDate.tsx
@@ -32,7 +32,7 @@ const Date = styled(Datetime)`
 
 export const InputDate = ({ onChange, value, text = null, width = 200 }) => (
   <div>
-    <Label>{text}</Label>
+    <Label width={width}>{text}</Label>
     <Date
       value={value}
       onChange={onChange}

--- a/src/components/common/Forms/InputDate.tsx
+++ b/src/components/common/Forms/InputDate.tsx
@@ -1,4 +1,5 @@
 import Datetime from 'react-datetime';
+import styled from 'styled-components';
 import 'react-datetime/css/react-datetime.css';
 
 // This is an example of usage of a component
@@ -6,4 +7,34 @@ import 'react-datetime/css/react-datetime.css';
 // and contorledValue.unix() to get the timestamp.
 // https://www.npmjs.com/package/react-datetime API here
 // for example: onChange, onClose, onNavigate, etc.
-export const InputDate = () => <Datetime />;
+
+const Label = styled.div`
+  text-align: left;
+  font-size: smaller;
+  width: 200px;
+  margin: auto;
+`;
+const Date = styled(Datetime)`
+  input {
+    background-color: white;
+    border-radius: 6px;
+    border-color: #526dfe;
+    border-style: solid;
+    padding: 2% 0;
+    text-align: center;
+    font-size: x-large;
+    width: 200px;
+  }
+`;
+
+export const InputDate = ({ onChange, value, text = null }) => (
+  <div>
+    <Label>{text}</Label>
+    <Date
+      value={value}
+      onChange={onChange}
+      dateFormat="DD/MM/YYYY"
+      timeFormat={false}
+    />
+  </div>
+);

--- a/src/components/common/Forms/InputDate.tsx
+++ b/src/components/common/Forms/InputDate.tsx
@@ -11,7 +11,7 @@ import 'react-datetime/css/react-datetime.css';
 const Label = styled.div`
   text-align: left;
   font-size: smaller;
-  width: 200px;
+  width: ${props => `${props.width}px`};
   margin: auto;
 `;
 const Date = styled(Datetime)`
@@ -23,11 +23,14 @@ const Date = styled(Datetime)`
     padding: 2% 0;
     text-align: center;
     font-size: x-large;
-    width: 200px;
+    width: ${props => `${props.width}px`};
+  }
+  .rdtPicker {
+    width: 100%;
   }
 `;
 
-export const InputDate = ({ onChange, value, text = null }) => (
+export const InputDate = ({ onChange, value, text = null, width = 200 }) => (
   <div>
     <Label>{text}</Label>
     <Date
@@ -35,6 +38,7 @@ export const InputDate = ({ onChange, value, text = null }) => (
       onChange={onChange}
       dateFormat="DD/MM/YYYY"
       timeFormat={false}
+      width={width}
     />
   </div>
 );

--- a/src/hooks/useTokenService.ts
+++ b/src/hooks/useTokenService.ts
@@ -4,11 +4,13 @@ import { useContext } from '../contexts';
 interface UseABIServiceReturns {
   tokenData: any;
   tokenAth: number;
+  athDate: string;
 }
 
 export const useTokenService = (token: String): UseABIServiceReturns => {
   const [tokenData, setTokenData] = useState();
   const [tokenAth, setAth] = useState();
+  const [athDate, setAthDate] = useState();
   const {
     context: { coingeckoService },
   } = useContext();
@@ -17,6 +19,7 @@ export const useTokenService = (token: String): UseABIServiceReturns => {
     const data = await coingeckoService.getCoinData(token);
     setTokenData(data);
     setAth(data['market_data'].ath.usd);
+    setAthDate(data['market_data']['ath_date'].usd);
   };
 
   useEffect(() => {
@@ -26,5 +29,6 @@ export const useTokenService = (token: String): UseABIServiceReturns => {
   return {
     tokenData,
     tokenAth,
+    athDate,
   };
 };

--- a/src/pages/ProposalSubmission/ContributorProposal.tsx
+++ b/src/pages/ProposalSubmission/ContributorProposal.tsx
@@ -414,6 +414,7 @@ export const ContributorProposalPage = observer(() => {
                   value={startDate}
                   onChange={setStartDateAndDxdOverride}
                   text={'Proposal Start Date:'}
+                  width={200}
                 />
                 {startDate.isBefore(moment(athDate)) ? (
                   <div>

--- a/src/pages/ProposalSubmission/ContributorProposal.tsx
+++ b/src/pages/ProposalSubmission/ContributorProposal.tsx
@@ -332,7 +332,6 @@ export const ContributorProposalPage = observer(() => {
   };
 
   const header = <div>Submit worker proposal</div>;
-  console.log({ athDate, startDate });
 
   const ModalContent = () => (
     <ModalContentWrap>
@@ -356,11 +355,6 @@ export const ContributorProposalPage = observer(() => {
         {calculateDiscountedValue(levels[selectedLevel]?.rep, discount)}% -{' '}
         {normalizeBalance(bnum(repReward ? repReward : '0')).toString()} REP
       </Values>
-      {/* <WarningText>
-        {periodEnd
-          ? 'If this is the second half of your payment then there is a chance DXD ATH changed and double check REP amount is accurate. If something is wrong please override the automatic values.'
-          : null}
-      </WarningText> */}
     </ModalContentWrap>
   );
 
@@ -419,18 +413,24 @@ export const ContributorProposalPage = observer(() => {
                 <InputDate
                   value={startDate}
                   onChange={setStartDateAndDxdOverride}
-                  text={'Start Date:'}
+                  text={'Proposal Start Date:'}
                 />
                 {startDate.isBefore(moment(athDate)) ? (
-                  <InputWrapper>
-                    $
-                    <TextInput
-                      placeholder="DXD ATH"
-                      type="number"
-                      onChange={event => setDXDOverride(event.target.value)}
-                      value={percentage}
-                    />
-                  </InputWrapper>
+                  <div>
+                    <WarningText>
+                      DXD all time high (ATH) has changed, please manually
+                      provide correct ATH as of start date
+                    </WarningText>
+                    <InputWrapper>
+                      $
+                      <TextInput
+                        placeholder="DXD ATH"
+                        type="number"
+                        onChange={event => setDXDOverride(event.target.value)}
+                        value={percentage}
+                      />
+                    </InputWrapper>
+                  </div>
                 ) : null}
               </Values>
             ) : null}

--- a/src/stores/DaoStore.ts
+++ b/src/stores/DaoStore.ts
@@ -1142,20 +1142,26 @@ export default class DaoStore {
 
   getRepAt(
     userAddress: string = ZERO_ADDRESS,
-    atBlock: number = 0
+    atBlock: number = 0,
+    atTime: number = 0
   ): {
     userRep: BigNumber;
     totalSupply: BigNumber;
   } {
     const { daoStore, providerStore, configStore } = this.context;
     const repEvents = daoStore.getCache().daoInfo.repEvents;
+    console.log({ repEvents });
     let userRep = bnum(0),
       totalSupply = bnum(0);
     if (atBlock === 0) atBlock = providerStore.getCurrentBlockNumber();
     const inL2 = configStore.getActiveChainName().indexOf('arbitrum') > -1;
 
     for (let i = 0; i < repEvents.length; i++) {
-      if (repEvents[i][inL2 ? 'l2BlockNumber' : 'l1BlockNumber'] < atBlock) {
+      if (
+        atTime > 0
+          ? repEvents[i].timestamp < atTime
+          : repEvents[i][inL2 ? 'l2BlockNumber' : 'l1BlockNumber'] < atBlock
+      ) {
         if (repEvents[i].event === 'Mint') {
           totalSupply = totalSupply.plus(repEvents[i].amount);
           if (repEvents[i].account === userAddress)
@@ -1170,12 +1176,12 @@ export default class DaoStore {
     return { userRep, totalSupply };
   }
 
+  // total supply calculation broken
   getRepEventsOfUser(
     userAddress: string = ZERO_ADDRESS,
     atBlock: number = 0
   ): {
     userRep: RepEvent[];
-    totalSupply: BigNumber;
   } {
     const { daoStore, providerStore, configStore } = this.context;
     const repEvents = daoStore.getCache().daoInfo.repEvents;
@@ -1192,7 +1198,7 @@ export default class DaoStore {
         }
       }
     }
-    return { userRep, totalSupply };
+    return { userRep };
   }
 
   getUsersRep(): {


### PR DESCRIPTION
This allows users to set the date to correctly calculate DXD price and REP allocation

For DXD if the start period is after the most recent ATH, then ATH is used. If before ATH then the user is prompted for the DXD price at time of proposal creation. (Wasnt possible to easily automate with coingecko API)

getRepAt function has been updated with optional atTime parameter allowing for the specification of a timestamp instead of block number which is used to find the total supply at the specified date to correctly calculate REP award. 

This contributes more to the problem of this page growing and needing split up which I believe is covered in the refactor. Sorry for adding more work to it. 

Closes #342 

<img width="1515" alt="Screenshot 2021-11-10 at 11 37 47" src="https://user-images.githubusercontent.com/39137239/141106429-ce733c81-e1e5-4550-8554-845091f1f2ed.png">
