### PR TITLE
Feature/rep display component

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "react-scripts": "^4.0.3",
     "react-select": "^4.3.1",
     "react-spring": "^8.0.27",
+    "react-string-replace": "^0.4.4",
     "react-switch": "^6.0.0",
     "react-use-gesture": "^7.0.16",
     "request": "^2.88.2",

--- a/src/components/RepDisplay/index.tsx
+++ b/src/components/RepDisplay/index.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+import styled from 'styled-components';
+import BigNumber from 'bignumber.js';
+import moment from 'moment';
+import { useContext } from '../../contexts';
+import { bnum, normalizeBalance, ZERO_ADDRESS } from '../../utils';
+
+interface RepDisplayProps {
+  rep: BigNumber;
+  timestamp?: number;
+  atBlock?: number;
+}
+
+const HoverHighlight = styled.span`
+  &:hover {
+    color: var(--blue-onHover);
+  }
+`;
+
+const RepDisplay: React.FC<RepDisplayProps> = ({ rep, atBlock, timestamp }) => {
+  const {
+    context: { daoStore },
+  } = useContext();
+
+  const [isHovering, setIsHovering] = useState(false);
+  const repNormalized = normalizeBalance(rep).toString();
+  const repPercent = bnum(rep)
+    .times(100)
+    .div(daoStore.getRepAt(ZERO_ADDRESS, atBlock).totalSupply)
+    .toFixed(4)
+    .toString();
+
+  return (
+    <HoverHighlight
+      onMouseEnter={() => setIsHovering(true)}
+      onMouseLeave={() => setIsHovering(false)}
+    >
+      {isHovering ? `${repPercent}%` : repNormalized} REP{' '}
+      {isHovering &&
+        timestamp &&
+        `as of ${moment.unix(timestamp).format('Do MMM YYYY')}`}
+    </HoverHighlight>
+  );
+};
+
+export default RepDisplay;

--- a/src/configs/xdai/config.json
+++ b/src/configs/xdai/config.json
@@ -24,6 +24,9 @@
         "address": "0x053f406aD40c9Eb8eB43aFf28DA0D0EC17dF8e44"
       }
     },
+    "schemes": {
+      "QuickWalletScheme": "0x983e0c64088E48b6AB7C76a8ABa3eE93d1C10aD5"
+    },
     "daostack": {
       "contributionRewardRedeemer": "0xd2cc17817c0d4cfc6819510b2e5288512122d71c",
       "schemeRegistrar": {

--- a/src/stores/ConfigStore.ts
+++ b/src/stores/ConfigStore.ts
@@ -299,6 +299,7 @@ export default class ConfigStore {
         name: string;
         defaultValue: string;
         decimals?: number;
+        isRep?: boolean;
       }[];
       decodeText: string;
     }[] = [
@@ -309,7 +310,13 @@ export default class ConfigStore {
         toName: 'DXdao Controller',
         functionName: 'mintReputation(uint256,address,address)',
         params: [
-          { type: 'uint256', name: '_amount', defaultValue: '', decimals: 18 },
+          {
+            type: 'uint256',
+            name: '_amount',
+            defaultValue: '',
+            decimals: 18,
+            isRep: true,
+          },
           { type: 'address', name: '_to', defaultValue: '' },
           {
             type: 'address',
@@ -317,7 +324,7 @@ export default class ConfigStore {
             defaultValue: networkContracts.avatar,
           },
         ],
-        decodeText: 'Mint of [PARAM_0] REP to [PARAM_1]',
+        decodeText: 'Mint of [PARAM_0] to [PARAM_1]',
       },
       {
         asset: ZERO_ADDRESS,
@@ -326,7 +333,13 @@ export default class ConfigStore {
         toName: 'DXdao Controller',
         functionName: 'burnReputation(uint256,address,address)',
         params: [
-          { type: 'uint256', name: '_amount', defaultValue: '', decimals: 18 },
+          {
+            type: 'uint256',
+            name: '_amount',
+            defaultValue: '',
+            decimals: 18,
+            isRep: true,
+          },
           { type: 'address', name: '_from', defaultValue: '' },
           {
             type: 'address',
@@ -334,7 +347,7 @@ export default class ConfigStore {
             defaultValue: networkContracts.avatar,
           },
         ],
-        decodeText: 'Burn of [PARAM_0] REP to [PARAM_1]',
+        decodeText: 'Burn of [PARAM_0] to [PARAM_1]',
       },
       {
         asset: ZERO_ADDRESS,

--- a/src/stores/ConfigStore.ts
+++ b/src/stores/ConfigStore.ts
@@ -328,6 +328,29 @@ export default class ConfigStore {
       },
       {
         asset: ZERO_ADDRESS,
+        from: '0x983e0c64088E48b6AB7C76a8ABa3eE93d1C10aD5',
+        to: networkContracts.controller,
+        toName: 'DXdao Controller',
+        functionName: 'mintReputation(uint256,address,address)',
+        params: [
+          {
+            type: 'uint256',
+            name: '_amount',
+            defaultValue: '',
+            decimals: 18,
+            isRep: true,
+          },
+          { type: 'address', name: '_to', defaultValue: '' },
+          {
+            type: 'address',
+            name: '_avatar',
+            defaultValue: networkContracts.avatar,
+          },
+        ],
+        decodeText: 'Mint of [PARAM_0] to [PARAM_1]',
+      },
+      {
+        asset: ZERO_ADDRESS,
         from: networkContracts.avatar,
         to: networkContracts.controller,
         toName: 'DXdao Controller',

--- a/src/stores/ConfigStore.ts
+++ b/src/stores/ConfigStore.ts
@@ -328,7 +328,7 @@ export default class ConfigStore {
       },
       {
         asset: ZERO_ADDRESS,
-        from: '0x983e0c64088E48b6AB7C76a8ABa3eE93d1C10aD5',
+        from: networkContracts.schemes?.QuickWalletScheme,
         to: networkContracts.controller,
         toName: 'DXdao Controller',
         functionName: 'mintReputation(uint256,address,address)',

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -372,17 +372,20 @@ export interface ProposalCalls {
   contractABI: any;
 }
 
+export interface CallParameterDefinition {
+  type: string;
+  name: string;
+  defaultValue: string;
+  decimals?: number;
+  isRep?: boolean;
+}
+
 export interface RecommendedCallUsed {
   asset: string;
   from: string;
   to: string;
   toName: string;
   functionName: string;
-  params: {
-    type: string;
-    name: string;
-    defaultValue: string;
-    decimals?: number;
-  }[];
+  params: CallParameterDefinition[];
   decodeText: string;
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -260,6 +260,7 @@ declare global {
     controller: string;
     permissionRegistry: string;
     utils: { [name: string]: string };
+    schemes?: any;
     daostack?: any;
     votingMachines: {
       [name: string]: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12878,7 +12878,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-"lodash@>=3.5 <5", lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.5, lodash@^4.7.0:
+"lodash@>=3.5 <5", lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -16432,6 +16432,13 @@ react-spring@^8.0.27:
   dependencies:
     "@babel/runtime" "^7.3.1"
     prop-types "^15.5.8"
+
+react-string-replace@^0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/react-string-replace/-/react-string-replace-0.4.4.tgz#24006fbe0db573d5be583133df38b1a735cb4225"
+  integrity sha512-FAMkhxmDpCsGTwTZg7p/2v+/GTmxAp73so3fbSvlAcBBX36ujiGRNEaM/1u+jiYQrArhns+7eE92g2pi5E5FUA==
+  dependencies:
+    lodash "^4.17.4"
 
 react-switch@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
This PR adds a simple reusable `RepDisplay` component which calculates and shows the REP % when hovering. It can also take a block number and adjust the percentage value accordingly. If a timestamp is passed in, it will show the date with the REP percentage.

I've also refactored the `RecommendedCalls` component to show `RepDisplay` in proposal call data. After spending too much time trying to do this with the existing `replaceAll`  method we were using, I gave up and changed the code to use a tiny utility library. (Let me know if that's not okay) Hopefully, now the code is cleaner and accommodating for any future React components we want to mix with the call data details.

Regular State:
![image](https://user-images.githubusercontent.com/25136207/141350927-f56f3ba6-a1c0-45ca-b15b-e64c10c454ad.png)

On Hover:
![image](https://user-images.githubusercontent.com/25136207/141351273-f815ea00-3063-478d-95a4-e8d92899d6ef.png)

This change closes #315.