### PR TITLE
feat: Add vesting contract creation to recommended calls for clear di…

### DIFF
--- a/src/stores/ConfigStore.ts
+++ b/src/stores/ConfigStore.ts
@@ -558,6 +558,22 @@ export default class ConfigStore {
         decodeText:
           'Set [PARAM_5] permission in asset [PARAM_0] from [FROM] to [PARAM_2] with function signature [PARAM_3] and value [PARAM_4]',
       },
+      {
+        asset: ZERO_ADDRESS,
+        from: ANY_ADDRESS,
+        to: networkContracts.utils.dxdVestingFactory,
+        toName: 'DXD Vesting Factory',
+        functionName: 'create(address,uint256,uint256,uint256,uint256)',
+        params: [
+          { type: 'address', name: 'to', defaultValue: '' },
+          { type: 'uint256', name: 'startDate', defaultValue: '' },
+          { type: 'uint256', name: 'cliff', defaultValue: '' },
+          { type: 'uint256', name: 'duration', defaultValue: '' },
+          { type: 'uint256', name: 'amount', defaultValue: '' },
+        ],
+        decodeText:
+          'Create vesting contract of [PARAM_4] DXD for [PARAM_0] starting [PARAM_1] for [PARAM_2] with [PARAM_3] cliff',
+      },
     ];
 
     if (networkContracts.utils.dxdVestingFactory) {


### PR DESCRIPTION
With blockscout giving CORS errors even in production which previously worked, we need to display what contributor proposals are doing.

This adds the vesting contract factory with the method create

<img width="609" alt="Screenshot 2021-11-17 at 15 25 31" src="https://user-images.githubusercontent.com/39137239/142229312-4d771326-7a17-49b2-a7b5-67ad9ebf97ec.png">

As a side note we need to translate these into ens names as well as proper times instead of seconds. 
