### PR TITLE
feat: Added pokt urls and service

### DIFF
--- a/src/components/Web3ReactManager/index.tsx
+++ b/src/components/Web3ReactManager/index.tsx
@@ -20,7 +20,6 @@ const Web3ReactManager = ({ children }) => {
   const location = useLocation();
   const history = useHistory();
   const rpcUrls = useRpcUrls();
-  console.log({ rpcUrls });
 
   const originalFetch = window.fetch;
   window.fetch = (url, opts): Promise<Response> => {

--- a/src/components/Web3ReactManager/index.tsx
+++ b/src/components/Web3ReactManager/index.tsx
@@ -21,6 +21,7 @@ const Web3ReactManager = ({ children }) => {
   const history = useHistory();
   const rpcUrls = useRpcUrls();
 
+  // Overriding default fetch to check for RPC url and setting correct headers if matched
   const originalFetch = window.fetch;
   window.fetch = (url, opts): Promise<Response> => {
     if (rpcUrls && Object.values(rpcUrls).includes(url) && opts) {

--- a/src/components/Web3ReactManager/index.tsx
+++ b/src/components/Web3ReactManager/index.tsx
@@ -20,6 +20,17 @@ const Web3ReactManager = ({ children }) => {
   const location = useLocation();
   const history = useHistory();
   const rpcUrls = useRpcUrls();
+  console.log({ rpcUrls });
+
+  const originalFetch = window.fetch;
+  window.fetch = (url, opts): Promise<Response> => {
+    if (rpcUrls && Object.values(rpcUrls).includes(url) && opts) {
+      opts.headers = opts.headers || {
+        'Content-Type': 'application/json',
+      };
+    }
+    return originalFetch(url, opts);
+  };
 
   const web3Context = useWeb3React();
   const {

--- a/src/components/common/BlockchainLink.tsx
+++ b/src/components/common/BlockchainLink.tsx
@@ -10,6 +10,7 @@ import {
 import { useContext } from '../../contexts';
 import { FiExternalLink } from 'react-icons/fi';
 import { useEffect, useState } from 'react';
+import { useRpcUrls } from 'provider/providerHooks';
 
 const AddressLink = styled.div`
   display: flex;
@@ -41,6 +42,8 @@ export const BlockchainLink = ({
     context: { configStore, ensService },
   } = useContext();
 
+  const rpcUrls = useRpcUrls();
+
   const networkName = configStore.getActiveChainName();
   const [ensName, setENSName] = useState('');
   const erc20Token = getERC20Token(text);
@@ -52,7 +55,7 @@ export const BlockchainLink = ({
       setENSName(response);
     }
     getENS();
-  }, [text]);
+  }, [text, rpcUrls]);
 
   let formatedAddress;
   if (!ensName && !dxVoteContract && !erc20Token) {

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -9,6 +9,7 @@ import PinataService from '../services/PinataService';
 import EtherscanService from '../services/EtherscanService';
 import CoingeckoService from '../services/CoingeckoService';
 import InfuraService from '../services/InfuraService';
+import PoktService from '../services/PoktService';
 import AlchemyService from '../services/AlchemyService';
 import CustomRpcService from '../services/CustomRpcService';
 import ENSService from '../services/ENSService';
@@ -54,6 +55,7 @@ export default class RootContext {
   etherscanService: EtherscanService;
   coingeckoService: CoingeckoService;
   infuraService: InfuraService;
+  poktService: PoktService;
   alchemyService: AlchemyService;
   customRpcService: CustomRpcService;
   ensService: ENSService;
@@ -77,6 +79,7 @@ export default class RootContext {
     this.etherscanService = new EtherscanService(this);
     this.coingeckoService = new CoingeckoService(this);
     this.infuraService = new InfuraService(this);
+    this.poktService = new PoktService(this);
     this.alchemyService = new AlchemyService(this);
     this.customRpcService = new CustomRpcService(this);
     this.ensService = new ENSService(this);

--- a/src/pages/Configuration.tsx
+++ b/src/pages/Configuration.tsx
@@ -49,6 +49,7 @@ const ConfigPage = observer(() => {
       pinataService,
       etherscanService,
       infuraService,
+      poktService,
       alchemyService,
       customRpcService,
     },
@@ -64,6 +65,7 @@ const ConfigPage = observer(() => {
   const [infuraKeyStatus, setInfuraKeyStatus] = React.useState(
     infuraService.auth
   );
+  const [poktStatus, setPoktStatus] = React.useState(poktService.auth);
   const [alchemyKeyStatus, setAlchemyKeyStatus] = React.useState(
     alchemyService.auth
   );
@@ -90,11 +92,13 @@ const ConfigPage = observer(() => {
     await pinataService.isAuthenticated();
     await etherscanService.isAuthenticated(networkName);
     await infuraService.isAuthenticated();
+    await poktService.isAuthenticated();
     await alchemyService.isAuthenticated();
     await customRpcService.isAuthenticated();
     setPinataKeyStatus(pinataService.auth);
     setEtherscanApiStatus(etherscanService.auth);
     setInfuraKeyStatus(infuraService.auth);
+    setPoktStatus(poktService.auth);
     setAlchemyKeyStatus(alchemyService.auth);
     setCustomRpcUrlStatus(customRpcService.auth);
   }
@@ -150,12 +154,27 @@ const ConfigPage = observer(() => {
             value={localConfig.rpcType}
           >
             <option value="">Default</option>
+            <option value="pokt">Pokt</option>
             <option value="infura">Infura</option>
             <option value="alchemy">Alchemy</option>
             <option value="custom">Custom</option>
           </Dropdown>
         </Row>
 
+        {localConfig.rpcType === 'pokt' && (
+          <Row>
+            <FormLabel>Pokt:</FormLabel>
+            <InputBox
+              type="text"
+              serviceName="pokt"
+              onChange={event =>
+                onApiKeyValueChange(event.target.value, 'pokt')
+              }
+              value={localConfig.pokt}
+            ></InputBox>
+            <FormLabel>{poktStatus ? <FiCheckCircle /> : <FiX />}</FormLabel>
+          </Row>
+        )}
         {localConfig.rpcType === 'infura' && (
           <Row>
             <FormLabel>Infura:</FormLabel>

--- a/src/provider/providerHooks.ts
+++ b/src/provider/providerHooks.ts
@@ -66,7 +66,13 @@ export function useEagerConnect() {
 
 export function useRpcUrls() {
   const {
-    context: { infuraService, alchemyService, customRpcService, configStore },
+    context: {
+      infuraService,
+      poktService,
+      alchemyService,
+      customRpcService,
+      configStore,
+    },
   } = useContext();
   const preferredRpc = configStore.getLocalConfig().rpcType;
   const [rpcUrls, setRpcUrls] = useState(null);
@@ -84,6 +90,8 @@ export function useRpcUrls() {
       return infuraService.getRpcUrls();
     } else if (preferredRpc === 'alchemy' && alchemyService.auth) {
       return alchemyService.getRpcUrls();
+    } else if (preferredRpc === 'pokt' && poktService.auth) {
+      return poktService.getRpcUrls();
     } else if (preferredRpc === 'custom' && customRpcService.auth) {
       return customRpcService.getRpcUrls();
     } else {

--- a/src/services/CustomRpcService.ts
+++ b/src/services/CustomRpcService.ts
@@ -14,7 +14,6 @@ export default class CustomRpcService {
     const customRpcUrl = this.context.configStore.getLocalConfig().customRpcUrl;
 
     if (customRpcUrl && customRpcUrl.length > 0) {
-      console.log('testing');
       try {
         const auth = await axios({
           method: 'POST',
@@ -25,11 +24,7 @@ export default class CustomRpcService {
             params: [],
             id: 1,
           },
-          headers: {
-            'Content-Type': 'application/json',
-          },
         });
-        console.log({ auth });
         this.auth = auth.status === 200;
       } catch (e) {
         this.auth = false;

--- a/src/services/PoktService.ts
+++ b/src/services/PoktService.ts
@@ -1,8 +1,9 @@
 import RootContext from '../contexts';
 import axios from 'axios';
-import { ETH_NETWORKS_IDS } from 'provider/connectors';
+import { ETH_NETWORKS_IDS, DEFAULT_ETH_CHAIN_ID } from 'provider/connectors';
+import { DEFAULT_RPC_URLS, POKT_NETWORK_URLS } from 'utils';
 
-export default class CustomRpcService {
+export default class poktService {
   context: RootContext;
   auth: Boolean = false;
 
@@ -11,25 +12,20 @@ export default class CustomRpcService {
   }
 
   async isAuthenticated() {
-    const customRpcUrl = this.context.configStore.getLocalConfig().customRpcUrl;
+    const poktAPIKey = this.context.configStore.getLocalConfig().pokt;
 
-    if (customRpcUrl && customRpcUrl.length > 0) {
-      console.log('testing');
+    if (poktAPIKey && poktAPIKey.length > 0) {
       try {
         const auth = await axios({
           method: 'POST',
-          url: customRpcUrl,
+          url: POKT_NETWORK_URLS[DEFAULT_ETH_CHAIN_ID],
           data: {
             jsonrpc: '2.0',
             method: 'eth_blockNumber',
             params: [],
             id: 1,
           },
-          headers: {
-            'Content-Type': 'application/json',
-          },
         });
-        console.log({ auth });
         this.auth = auth.status === 200;
       } catch (e) {
         this.auth = false;
@@ -40,11 +36,20 @@ export default class CustomRpcService {
   }
 
   getRpcUrls() {
-    const customRpcUrl = this.context.configStore.getLocalConfig().customRpcUrl;
-    if (!customRpcUrl) return null;
+    const poktAPIKey = this.context.configStore.getLocalConfig().pokt;
+    if (!poktAPIKey) return null;
 
     return ETH_NETWORKS_IDS.reduce((prevUrls, chainId) => {
-      prevUrls[chainId] = customRpcUrl;
+      const poktNetworkName = POKT_NETWORK_URLS[chainId];
+
+      let poktUrl = null;
+      if (poktNetworkName) {
+        poktUrl = poktNetworkName;
+      } else {
+        poktUrl = DEFAULT_RPC_URLS[chainId];
+      }
+
+      prevUrls[chainId] = poktUrl;
       return prevUrls;
     }, {});
   }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -22,7 +22,7 @@ export const NETWORKS: ChainConfig[] = [
     id: 1,
     name: 'mainnet',
     displayName: 'Ethereum Mainnet',
-    defaultRpc: `https://eth-mainnet.alchemyapi.io/v2/${defaultAlchemyKey}`,
+    defaultRpc: `https://eth-mainnet.gateway.pokt.network/v1/lb/610e4d3118656e00369b9b05`,
     nativeAsset: {
       name: 'Ethereum',
       symbol: 'ETH',
@@ -35,7 +35,7 @@ export const NETWORKS: ChainConfig[] = [
     id: 4,
     name: 'rinkeby',
     displayName: 'Rinkeby Testnet',
-    defaultRpc: `https://eth-rinkeby.alchemyapi.io/v2/${defaultAlchemyKey}`,
+    defaultRpc: `https://eth-rinkeby.gateway.pokt.network/v1/lb/61116c81a585a20035149067`,
     nativeAsset: {
       name: 'Ethereum',
       symbol: 'ETH',
@@ -48,7 +48,7 @@ export const NETWORKS: ChainConfig[] = [
     id: 100,
     name: 'xdai',
     displayName: 'xDai Chain',
-    defaultRpc: `https://rpc.xdaichain.com/`,
+    defaultRpc: `https://poa-xdai.gateway.pokt.network/v1/lb/610e4ed818656e00369b9ccc`,
     nativeAsset: {
       name: 'xDai',
       symbol: 'xDAI',
@@ -139,6 +139,12 @@ export const ALCHEMY_NETWORK_URLS = {
   '4': 'eth-rinkeby.alchemyapi.io',
   '42161': 'arb-mainnet.g.alchemy.com',
   '421611': 'arb-rinkeby.g.alchemy.com',
+};
+
+export const POKT_NETWORK_URLS = {
+  '1': 'https://eth-mainnet.gateway.pokt.network/v1/lb/610e4d3118656e00369b9b05',
+  '4': 'https://eth-rinkeby.gateway.pokt.network/v1/lb/61116c81a585a20035149067',
+  '100': 'https://poa-xdai.gateway.pokt.network/v1/lb/610e4ed818656e00369b9ccc',
 };
 
 export const NETWORK_APIS: { [name: string]: string } = NETWORKS.reduce(


### PR DESCRIPTION
Closes #390 

Requires a kind of ugly fix to force RPC connections to use correct header content types as there is no way of altering them with web3-react and pokt returns a 415 if incorrect.

Uses pokt as default RPC for mainnet, rinkeby and xdai