### PR TITLE
removing 1 space allocation for item

### DIFF
--- a/src/components/Guilds/ProposalCard/index.tsx
+++ b/src/components/Guilds/ProposalCard/index.tsx
@@ -76,6 +76,8 @@ const BorderedIconDetailWrapper = styled(IconDetailWrapper)`
   border: 1px solid #000;
   border-radius: 1rem;
   padding: 0.25rem 0.8rem;
+  flex: none;
+  display: flex;
 `;
 
 const ProposalStatusWrapper = styled.div`


### PR DESCRIPTION
A fix to avoid items to take flex 1 space. 
