### PR TITLE
fix: Typos in stake and vote components

### DIFF
--- a/src/components/Proposal/Stakes/index.tsx
+++ b/src/components/Proposal/Stakes/index.tsx
@@ -58,7 +58,10 @@ const Stakes = () => {
   const redeemsLeft = daoStore.getUserRedeemsLeft(account);
 
   const votingMachineTokenName =
-    votingMachines.gen && scheme.votingMachine === votingMachines.gen.address
+    (votingMachines.gen &&
+      scheme.votingMachine === votingMachines.gen.address) ||
+    (votingMachines.gen2 &&
+      scheme.votingMachine === votingMachines.gen2.address)
       ? 'GEN'
       : 'DXD';
 

--- a/src/components/Proposal/Stakes/index.tsx
+++ b/src/components/Proposal/Stakes/index.tsx
@@ -60,7 +60,7 @@ const Stakes = () => {
   const votingMachineTokenName =
     votingMachines.gen && scheme.votingMachine === votingMachines.gen.address
       ? 'GEN'
-      : 'DX';
+      : 'DXD';
 
   const { dxdApproved, genApproved } = userStore.getUserInfo();
   const votingMachineTokenApproved =
@@ -207,7 +207,9 @@ const Stakes = () => {
 
       {stakedAmount.toNumber() > 0 ? (
         <SpaceAroundRow>
-          Already staked {stakedAmount.toNumber() > 0 ? 'for' : 'against'} with
+          {`Already staked ${
+            stakedAmount.toNumber() > 0 ? 'for' : 'against'
+          } with `}
           {formatBalance(stakedAmount).toString()} {votingMachineTokenName}
         </SpaceAroundRow>
       ) : (

--- a/src/components/Proposal/Votes/index.tsx
+++ b/src/components/Proposal/Votes/index.tsx
@@ -236,16 +236,14 @@ const Votes = () => {
         votedAmount.toNumber() !== 0 && (
           <SpaceAroundRow>
             <TextCenter>
-              {' '}
-              Already voted {votedAmount.toNumber() > 0
-                ? 'for'
-                : 'against'}{' '}
+              {`
+              Already voted ${votedAmount.toNumber() > 0 ? 'for' : 'against'}
               with
-              {votedAmount
+              ${votedAmount
                 .times('100')
                 .div(totalRepAtProposalCreation)
                 .toFixed(2)}
-              % REP
+              % REP`}
             </TextCenter>
           </SpaceAroundRow>
         )


### PR DESCRIPTION
I fixed this ages ago for #366 but due to not having time to finish that issue I'll add these fixes in here to get them deployed faster
I also just realised the issue was highlighting another issue where DXD was shown instead of GEN and it turns out its due to there being another gen2 voting machine so I added a check for this address to match for gen also.
Closes #373 