### PR TITLE
fix: Adding sleep before checking ipfs

### DIFF
--- a/src/services/IPFSService.ts
+++ b/src/services/IPFSService.ts
@@ -103,10 +103,10 @@ export default class IPFSService {
 
     let uploaded = false;
     while (!uploaded) {
+      await sleep(1000);
       const ipfsContent = await this.getContentFromIPFS(hash);
       console.debug('[IPFS CONTENT]', ipfsContent);
       if (JSON.stringify(ipfsContent) === bodyTextToUpload) uploaded = true;
-      await sleep(1000);
     }
     return hash;
   }


### PR DESCRIPTION
I think there is an issue where we check immediately for an uploaded ipfs hash but it is not yet available, this should fix that by pausing before checking gateways
Since we now don't let the user proceed without a working ipfs this is more important to prevent infinite spinning

Going to test some more and see if I can replicate the infinite loading some more