### PR TITLE
fix: Removing .link from prod env for .limo

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -82,7 +82,7 @@ const Header = observer(() => {
 
   const { active, account } = providerStore.getActiveWeb3React();
 
-  const isTestingEnv = !window?.location?.href?.includes('dxvote.eth.link');
+  const isTestingEnv = !window?.location?.href?.includes('dxvote.eth');
 
   if (!active) {
     return (

--- a/src/stores/ConfigStore.ts
+++ b/src/stores/ConfigStore.ts
@@ -49,7 +49,7 @@ export default class ConfigStore {
     const { ensService, ipfsService } = this.context;
 
     let networkConfig = defaultAppConfigs[networkName];
-    const isTestingEnv = !window?.location?.href?.includes('dxvote.eth.link');
+    const isTestingEnv = !window?.location?.href?.includes('dxvote.eth');
 
     try {
       const metadataHash = await ensService.resolveContentHash(


### PR DESCRIPTION
Since we use .limo as an alternative we are better to just use dxvote.eth as a check for production to avoid showing testing env messages in .limo