### PR TITLE
Fix cache voting machine events

### DIFF
--- a/scripts/buildCache.ts
+++ b/scripts/buildCache.ts
@@ -27,23 +27,23 @@ const rl = readline.createInterface({ input, output });
 
 const buildConfig = {
   mainnet: {
-    toBlock: 13797817,
+    toBlock: 13894185,
     reset: false,
   },
   xdai: {
-    toBlock: 19560176,
+    toBlock: 19815055,
     reset: false,
   },
   arbitrum: {
-    toBlock: 3823419,
+    toBlock: 4135119,
     reset: false,
   },
   rinkeby: {
-    toBlock: 9790490,
+    toBlock: 9893720,
     reset: false,
   },
   arbitrumTestnet: {
-    toBlock: 7404680,
+    toBlock: 7966665,
     reset: false,
   },
 };

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -295,9 +295,11 @@ export const updateVotingMachine = async function (
   let newVotingMachineEvents = sortEvents(
     await getEvents(web3, votingMachine, fromBlock, toBlock, 'allEvents')
   );
+  const avatarAddress = web3.utils.toChecksumAddress(
+    networkContractsConfig.avatar
+  );
   const votingMachineEventsInCache =
     networkCache.votingMachines[votingMachine._address].events;
-
   newVotingMachineEvents.map(votingMachineEvent => {
     const proposalCreated =
       votingMachineEventsInCache.newProposal.findIndex(
@@ -309,8 +311,7 @@ export const updateVotingMachine = async function (
     let existEvent;
 
     if (
-      votingMachineEvent.returnValues._organization ===
-        networkContractsConfig.avatar ||
+      votingMachineEvent.returnValues._organization === avatarAddress ||
       (votingMachineEvent.event === 'StateChange' && proposalCreated)
     )
       switch (votingMachineEvent.event) {

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -467,7 +467,6 @@ export const updateVotingMachine = async function (
           break;
       }
   });
-
   networkCache.votingMachines[votingMachine._address].events =
     votingMachineEventsInCache;
 

--- a/src/configs/arbitrum/config.json
+++ b/src/configs/arbitrum/config.json
@@ -1,8 +1,8 @@
 {
   "cache": {
     "fromBlock": 338923,
-    "ipfsHash": "QmTVTpyWavajLwRZivraKgRd3zAdpeRCArAwYnhb8rW2ds",
-    "toBlock": 3823419
+    "ipfsHash": "QmYeVwx1kSf5d9RFBMKkPDiF1hD31y31GBCaDbsitgdgQb",
+    "toBlock": 4135119
   },
   "contracts": {
     "avatar": "0x2B240b523f69b9aF3adb1C5924F6dB849683A394",

--- a/src/configs/arbitrumTestnet/config.json
+++ b/src/configs/arbitrumTestnet/config.json
@@ -1,8 +1,8 @@
 {
   "cache": {
     "fromBlock": 3995726,
-    "ipfsHash": "QmeKHY2qaosfRxaSqd7paZ661n3a5X9JtzqL7fQTSpdgi5",
-    "toBlock": 7404680
+    "ipfsHash": "QmUVwNPdydyiLeEXaknPqJDohpufdbh7sMtYNFm5mVCdbL",
+    "toBlock": 7966665
   },
   "contracts": {
     "avatar": "0x6370B3Ba7D9bAd94b35dC9073540E562bDe5Fdc3",

--- a/src/configs/default.json
+++ b/src/configs/default.json
@@ -1,7 +1,7 @@
 {
-  "mainnet": "Qmcoi4AXGDtDWxcBZB2o9uCA3wWQc7wYgVgt3sR2nDBnsG",
-  "xdai": "QmY9Gk178ySJjoq3CdjgF6sAJpPENkDR6ToY76uCmAVVJq",
-  "arbitrum": "QmYbh91K9EvcLvz9UDSHpu4Jrk9sGaS5pFKcqiDWanwxjj",
-  "rinkeby": "QmUAuJhaXCgGbELFLeZwNLkFZ65fEHBqDoLXjPoghwfKNC",
-  "arbitrumTestnet": "Qmdxrp3S8W1TYdPBC3rzyPzVseZUP8pwCozKwfHyu8RkqQ"
+  "mainnet": "QmPyHJdGHvEJUeMPQKu1MYpjfWx6t2pU5H47rovRzdGJiK",
+  "xdai": "QmWkbzGywX3Wf7pbyUGK7iMj7Z7J92gwYdxcRH7iD6J8Yk",
+  "arbitrum": "QmUYJkK6ht4BbkXVQ9c1XKPXvKzY3AwaBgErN5Sjg6CjEx",
+  "rinkeby": "Qme2aeR9bJ8U4wW9FhGvgxitzqrPGZjVLdE8xgcjM3KfHy",
+  "arbitrumTestnet": "QmeWgcc8dWWnaySg92aaZ7QJq2L5GMVT1HFtarxibGkjF9"
 }

--- a/src/configs/mainnet/config.json
+++ b/src/configs/mainnet/config.json
@@ -1,8 +1,8 @@
 {
   "cache": {
     "fromBlock": 7219912,
-    "ipfsHash": "QmNsTYdRZWBiLwCAb5KvDKoXgsJ4e4jryeJi8jSEL4oYEV",
-    "toBlock": 13797817
+    "ipfsHash": "QmUYkfrzdKDgQWQPtZ7k4Q7gqmBugJgJJP6WDhLBfxwAv1",
+    "toBlock": 13894185
   },
   "contracts": {
     "avatar": "0x519b70055af55a007110b4ff99b0ea33071c720a",

--- a/src/configs/rinkeby/config.json
+++ b/src/configs/rinkeby/config.json
@@ -1,8 +1,8 @@
 {
   "cache": {
     "fromBlock": 9234792,
-    "ipfsHash": "QmakAnLcK5jEA4bErN9wot9Gn6yNe9q4UHF5hvZ37uZgJG",
-    "toBlock": 9790490
+    "ipfsHash": "QmQhhFRJU3bC1TGJ1bvxFLWVgj4KGZXWcPkoPg6Q6hTKwy",
+    "toBlock": 9893720
   },
   "contracts": {
     "avatar": "0x1A639b50D807ce7e61Dc9eeB091e6Cea8EcB1595",

--- a/src/configs/xdai/config.json
+++ b/src/configs/xdai/config.json
@@ -1,8 +1,8 @@
 {
   "cache": {
     "fromBlock": 13060713,
-    "ipfsHash": "QmSGacyGLjY3DNEPYKTQkAn7FcXmbq8g8xPrmFDL57TaZN",
-    "toBlock": 19560176
+    "ipfsHash": "QmWCaS4GmZRGD5cP42TJZA3D65tyqUfT1E5noUM92pqmQb",
+    "toBlock": 19815055
   },
   "contracts": {
     "avatar": "0xe716EC63C5673B3a4732D22909b38d779fa47c3F",


### PR DESCRIPTION
The avatar of the events was compared against the avatar address form the config that is not checksumed, this was causing that the voting machine events were not added in the cache file.

The cache will be reseted using this config:
```
const buildConfig = {
  mainnet: {
    toBlock: 13894185,
    reset: true,
  },
  xdai: {
    toBlock: 19815055,
    reset: true,
  },
  arbitrum: {
    toBlock: 4135119,
    reset: true,
  },
  rinkeby: {
    toBlock: 9893720,
    reset: true,
  },
  arbitrumTestnet: {
    toBlock: 7966665,
    reset: true,
  },
};
```

Closes #372 