### PR TITLE
fix: Change to send current address in redeem call

### DIFF
--- a/src/components/Proposal/Status/index.tsx
+++ b/src/components/Proposal/Status/index.tsx
@@ -35,7 +35,7 @@ const Status = () => {
           scheme.address,
           scheme.votingMachine,
           proposalId,
-          proposal.to[0]
+          account
         );
         break;
       case 5:


### PR DESCRIPTION
Dave raised an issue where this was sending the address of the controller in the transaction and not the user's address like alchemy does. This seems to make more sense to me and would solve it, but would like @AugustoL opinion.

Closes #537 