### PR TITLE
Quiet Ending Period Sorting Incorrectly

### DIFF
--- a/src/hooks/useFilterCriteria.ts
+++ b/src/hooks/useFilterCriteria.ts
@@ -38,6 +38,7 @@ export const useFilterCriteria = (): useFilterCriteriaReturns => {
 
   useEffect(() => {
     const allProposals = daoStore.getAllProposals();
+
     // (QuitedEndingPeriod || Queded) && positiveVotes >= 10% (Ordered from time to finish, from lower to higher)
     const stateEarliestAbove10 = allProposals
       .filter(proposal => {
@@ -46,10 +47,7 @@ export const useFilterCriteria = (): useFilterCriteriaReturns => {
         ).totalSupply;
 
         return (
-          (proposal.stateInVotingMachine ===
-            VotingMachineProposalState.QuietEndingPeriod ||
-            proposal.stateInVotingMachine ===
-              VotingMachineProposalState.Queued) &&
+          proposal.stateInVotingMachine === VotingMachineProposalState.Queued &&
           proposal.positiveVotes
             .div(repAtCreation)
             .times(100)
@@ -65,6 +63,15 @@ export const useFilterCriteria = (): useFilterCriteriaReturns => {
         (proposal): Boolean =>
           proposal.stateInVotingMachine === VotingMachineProposalState.Boosted
       )
+      .sort(orderByNewestTimeToFinish);
+
+    const stateQuiteEndingProposals = allProposals
+      .filter(proposal => {
+        return (
+          proposal.stateInVotingMachine ===
+          VotingMachineProposalState.QuietEndingPeriod
+        );
+      })
       .sort(orderByNewestTimeToFinish);
 
     const statePreBoosted = allProposals
@@ -83,10 +90,7 @@ export const useFilterCriteria = (): useFilterCriteriaReturns => {
         ).totalSupply;
 
         return (
-          (proposal.stateInVotingMachine ===
-            VotingMachineProposalState.QuietEndingPeriod ||
-            proposal.stateInVotingMachine ===
-              VotingMachineProposalState.Queued) &&
+          proposal.stateInVotingMachine === VotingMachineProposalState.Queued &&
           proposal.positiveVotes
             .div(repAtCreation)
             .times(100)
@@ -105,9 +109,10 @@ export const useFilterCriteria = (): useFilterCriteriaReturns => {
       .sort(orderByOldestTimeToFinish);
 
     setFilteredProposals([
-      ...stateEarliestAbove10,
       ...stateBoosted,
       ...statePreBoosted,
+      ...stateQuiteEndingProposals,
+      ...stateEarliestAbove10,
       ...stateEarliestUnder10,
       ...stateExecuted,
     ]);

--- a/src/hooks/useFilterCriteria.ts
+++ b/src/hooks/useFilterCriteria.ts
@@ -39,7 +39,7 @@ export const useFilterCriteria = (): useFilterCriteriaReturns => {
   useEffect(() => {
     const allProposals = daoStore.getAllProposals();
 
-    // (QuitedEndingPeriod || Queded) && positiveVotes >= 10% (Ordered from time to finish, from lower to higher)
+    // Queded && positiveVotes >= 10% (Ordered from time to finish, from lower to higher)
     const stateEarliestAbove10 = allProposals
       .filter(proposal => {
         const repAtCreation = getRep(
@@ -82,7 +82,7 @@ export const useFilterCriteria = (): useFilterCriteriaReturns => {
       )
       .sort(orderByNewestTimeToFinish);
 
-    // (QuitedEndingPeriod || Queded) && positiveVotes < 10% (Ordered from time to finish, from lower to higher)
+    //   Queded && positiveVotes < 10% (Ordered from time to finish, from lower to higher)
     const stateEarliestUnder10 = allProposals
       .filter((proposal): Boolean => {
         const repAtCreation = getRep(


### PR DESCRIPTION
* Closes #572 
* Removed `QuiteEndingPeriod` from `StateEarliestUnder10` and `StateEarliestAbove10` and created its own filtered array.

The filtering was previously amended by @luchux in discussion with the DXvote power users however I can't remember why exactly the criteria was chosen, so would need @luchux guidance on this one. 
