### PR TITLE
fix: Changing vote max to not round up

### DIFF
--- a/src/components/Proposal/Votes/index.tsx
+++ b/src/components/Proposal/Votes/index.tsx
@@ -187,7 +187,7 @@ const Votes = () => {
 
   const repPercentageAtCreation = toPercentage(
     userRepAtProposalCreation.div(totalRepAtProposalCreation)
-  ).toFixed(2, 4);
+  ).toFixed(2);
 
   const positiveVotes = toPercentage(
     proposal.positiveVotes.div(totalRepAtProposalCreation)


### PR DESCRIPTION
Fixing bug where input amount was rounded up suggesting the user should vote with more rep than they have causing a failed transaction