### PR TITLE
Feature/search by proposer address

### DIFF
--- a/src/services/ENSService.ts
+++ b/src/services/ENSService.ts
@@ -31,6 +31,18 @@ export default class ENSService {
     return name;
   }
 
+  async resolveENSAddress(ensName: string) {
+    let address = null;
+    try {
+      address = await this.web3Provider.resolveName(ensName);
+    } catch (e) {
+      console.warn(
+        '[ENSService] Error while trying to reverse resolve ENS address.'
+      );
+    }
+    return address;
+  }
+
   async resolveContentHash(ensName: string): Promise<string | null> {
     const resolver = await this.web3Provider.getResolver(ensName);
     const contentHash = await resolver.getContentHash();


### PR DESCRIPTION
Improves ENS proposals search behavior to take the proposer's Ethereum address into consideration. Additionally, when an ENS .eth name is entered into the search field, it is resolved into the Eth address before searching.

![image](https://user-images.githubusercontent.com/25136207/151192475-2bb7ea88-628a-40bc-bc5f-4dce0e3ce09d.png)

Closes #555.