### PR TITLE
Feature/dxvote md preview improvements

### DIFF
--- a/src/components/ProposalSubmission/Custom/Preview.tsx
+++ b/src/components/ProposalSubmission/Custom/Preview.tsx
@@ -25,6 +25,7 @@ export const Preview = ({ descriptionText, schemeToUse }) => {
           border: '1px solid gray',
           padding: '20px 10px',
         }}
+        linkTarget="_blank"
       />
       {schemeToUse.type === 'ContributionReward' ||
       schemeToUse.type === 'GenericMulticall' ||

--- a/src/components/ProposalSubmission/Custom/Preview.tsx
+++ b/src/components/ProposalSubmission/Custom/Preview.tsx
@@ -26,6 +26,8 @@ export const Preview = ({ descriptionText, schemeToUse }) => {
           padding: '20px 10px',
         }}
         linkTarget="_blank"
+        skipHtml
+        escapeHtml
       />
       {schemeToUse.type === 'ContributionReward' ||
       schemeToUse.type === 'GenericMulticall' ||

--- a/src/pages/FAQ.tsx
+++ b/src/pages/FAQ.tsx
@@ -236,6 +236,8 @@ The downstake for proposal is calculated when the proposal is created, by using 
         style={{
           padding: '20px 10px',
         }}
+        skipHtml
+        escapeHtml
       />
     </FAQBox>
   );

--- a/src/pages/Metadata.tsx
+++ b/src/pages/Metadata.tsx
@@ -178,12 +178,18 @@ export const CreateMetadataPage = observer(() => {
                 commands.orderedListCommand,
                 commands.checkedListCommand,
               ]}
+              previewOptions={{
+                skipHtml: true,
+                escapeHtml: true
+              }}
             />
             <PreviewWrapper>
               <PreviewHeader>Preview</PreviewHeader>
               <Preview
                 source={descriptionText}
                 linkTarget="_blank"
+                skipHtml
+                escapeHtml
               />
             </PreviewWrapper>
           </MarkdownWrapper>

--- a/src/pages/Metadata.tsx
+++ b/src/pages/Metadata.tsx
@@ -180,7 +180,7 @@ export const CreateMetadataPage = observer(() => {
               ]}
               previewOptions={{
                 skipHtml: true,
-                escapeHtml: true
+                escapeHtml: true,
               }}
             />
             <PreviewWrapper>

--- a/src/pages/Metadata.tsx
+++ b/src/pages/Metadata.tsx
@@ -181,7 +181,10 @@ export const CreateMetadataPage = observer(() => {
             />
             <PreviewWrapper>
               <PreviewHeader>Preview</PreviewHeader>
-              <Preview source={descriptionText} />
+              <Preview
+                source={descriptionText}
+                linkTarget="_blank"
+              />
             </PreviewWrapper>
           </MarkdownWrapper>
         </ProposalsWrapper>

--- a/src/pages/Proposal.tsx
+++ b/src/pages/Proposal.tsx
@@ -110,6 +110,8 @@ const ProposalPage = observer(() => {
               whiteSpace: 'pre-line',
             }}
             linkTarget="_blank"
+            skipHtml
+            escapeHtml
           />
           {proposal.descriptionHash.length > 0 && (
             <h3 style={{ margin: '0px' }}>

--- a/src/pages/Proposal.tsx
+++ b/src/pages/Proposal.tsx
@@ -109,6 +109,7 @@ const ProposalPage = observer(() => {
               padding: '20px 10px',
               whiteSpace: 'pre-line',
             }}
+            linkTarget="_blank"
           />
           {proposal.descriptionHash.length > 0 && (
             <h3 style={{ margin: '0px' }}>

--- a/src/pages/ProposalSubmission/Custom.tsx
+++ b/src/pages/ProposalSubmission/Custom.tsx
@@ -653,6 +653,10 @@ const NewProposalPage = observer(() => {
             commands.orderedListCommand,
             commands.checkedListCommand,
           ]}
+          previewOptions={{
+            skipHtml: true,
+            escapeHtml: true,
+          }}
         />
       ) : (
         <div />


### PR DESCRIPTION
Couple of improvements to DXvote proposal markdown rendering:
- Open proposal description links in different tab. Fixes #585.
- Skip and escape HTML in MD editor and previews.