### PR TITLE
bugfix: Fix issue with ENS cache loading in production.

### DIFF
--- a/src/stores/ConfigStore.ts
+++ b/src/stores/ConfigStore.ts
@@ -73,7 +73,7 @@ export default class ConfigStore {
 
       const configRefs = isTestingEnv
         ? defaultCacheConfig
-        : JSON.parse(await ipfsService.getContentFromIPFS(metadataHash));
+        : await ipfsService.getContentFromIPFS(metadataHash);
 
       const configContentHash = configRefs[this.getActiveChainName()];
       if (!configContentHash)
@@ -92,7 +92,8 @@ export default class ConfigStore {
     } catch (e) {
       console.error(
         '[ConfigStore] Could not get the config from ENS. Falling back to configs in the build.',
-        this.networkConfig
+        this.networkConfig,
+        e
       );
     }
 


### PR DESCRIPTION
Found an error log while doing something unrelated on DXvote production.

![image](https://user-images.githubusercontent.com/25136207/152583468-fdca17a8-9a7d-43c8-9d09-e996b7488ad9.png)

Upon investigation, it seems ENS cache loading might've been broken for the past month-ish on production. This bug totally went unnoticed on local environments because this code is behind a flag that checks if the current environment is *.dxvote.eth.

**Takeaway: We should not hide code behind flags that check whether the environment is production or not, unless its cosmetic.** 

_Thanks to @hhamud for helping test this._