### PR TITLE
fix: Fetching titles on new proposals for cache

### DIFF
--- a/src/services/CacheService.ts
+++ b/src/services/CacheService.ts
@@ -1680,18 +1680,21 @@ export default class UtilsService {
                     };
                   }
 
-                  const ipfsHash = descriptionHashToIPFSHash(
-                    schemeProposalInfo.descriptionHash
-                  );
-                  const title = (await fetchFromIpfs(ipfsHash)).title;
+                  var title;
+                  if (!schemeProposalInfo.title) {
+                    const ipfsHash = descriptionHashToIPFSHash(
+                      schemeProposalInfo.descriptionHash
+                    );
+                    title = (await fetchFromIpfs(ipfsHash)).title;
+                  } else {
+                    title = schemeProposalInfo.title;
+                  }
 
                   networkCache.proposals[proposalId] = {
                     id: proposalId,
                     scheme: schemeAddress,
                     to: schemeProposalInfo.to,
-                    title: schemeProposalInfo.title
-                      ? schemeProposalInfo.title
-                      : title,
+                    title: title,
                     callData: schemeProposalInfo.callData,
                     values: schemeProposalInfo.value.map(value => bnum(value)),
                     stateInScheme: Number(schemeProposalInfo.state),


### PR DESCRIPTION
We havent been fetching titles recently, this fetches the titles on client side loading of new blocks not only when updating the remote cache. 
It only attempts once but this is good to not slow down the loading speeds and also it only checks new proposal titles