### PR TITLE
fix(src/cache): fix failing cache when using outside provider

### DIFF
--- a/src/stores/BlockchainStore.ts
+++ b/src/stores/BlockchainStore.ts
@@ -69,7 +69,10 @@ export default class BlockchainStore {
           networkCache = JSON.parse(await match.text());
         }
 
-        if (networkCache?.version !== targetCacheVersion) {
+        if (
+          !networkCache.version ||
+          networkCache.version !== targetCacheVersion
+        ) {
           console.log('[Upgrade Cache]');
           networkCache = null;
         }

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -12,7 +12,7 @@ export const getEvents = async function (
   eventsToGet,
   maxBlocksPerFetch = MAX_BLOCKS_PER_EVENTS_FETCH
 ) {
-  if (web3._provider.host.indexOf('arbitrum.io/rpc') > 0)
+  if (web3._provider.host && web3._provider.host.indexOf('arbitrum.io/rpc') > 0)
     maxBlocksPerFetch = 99000;
   let events = [],
     to = Math.min(fromBlock + maxBlocksPerFetch, toBlock),
@@ -66,7 +66,7 @@ export const getRawEvents = async function (
   topicsToGet,
   maxBlocksPerFetch = MAX_BLOCKS_PER_EVENTS_FETCH
 ) {
-  if (web3._provider.host.indexOf('arbitrum.io/rpc') > 0)
+  if (web3._provider.host && web3._provider.host.indexOf('arbitrum.io/rpc') > 0)
     maxBlocksPerFetch = 99000;
   let events = [],
     to = Math.min(fromBlock + maxBlocksPerFetch, toBlock),


### PR DESCRIPTION
When using metamask the events fetch was failing and I was getting less proposals if I was using the default RPC provider,this fixes it.