### PR TITLE
fix: Increasing block tolerance to 5

### DIFF
--- a/src/stores/BlockchainStore.ts
+++ b/src/stores/BlockchainStore.ts
@@ -78,7 +78,7 @@ export default class BlockchainStore {
           networkCache = null;
         }
 
-        const blockNumber = (await library.eth.getBlockNumber()) - 1;
+        const blockNumber = (await library.eth.getBlockNumber()) - 5;
 
         const newestCacheIpfsHash = configStore.getCacheIPFSHash(networkName);
 


### PR DESCRIPTION
We have been seeing strange bugs in dxvote with proposals not appearing and they are 100% always fixed by a cache refresh. This suggests it is not a fault with the actual code being run but perhaps that since it happens when updating a local cache stored in the browser that maybe the toBlock being set to the new fromBlock for loading is missing proposals. 
This is a bit of a bad way to address this but we can test it in develop like this for now.
By increasing the tolerance here we have more of an overlap to hopefully catch proposals that were slipping past the cache code previously. More of a debugging step since this is not an efficient solution. 