### PR TITLE
fix(redeem): fix wrong access to redeemer address

### DIFF
--- a/src/components/Proposal/Stakes/index.tsx
+++ b/src/components/Proposal/Stakes/index.tsx
@@ -124,10 +124,10 @@ const Stakes = () => {
   const redeem = function () {
     if (
       scheme.type === 'ContributionReward' &&
-      networkContracts.daostack.contributionReward.redeemer
+      networkContracts.daostack[scheme.address].redeemer
     ) {
       daoService.redeemContributionReward(
-        networkContracts.daostack.contributionReward.redeemer,
+        networkContracts.daostack[scheme.address].redeemer,
         scheme.address,
         scheme.votingMachine,
         proposalId,

--- a/src/components/Proposal/Status/index.tsx
+++ b/src/components/Proposal/Status/index.tsx
@@ -31,7 +31,7 @@ const Status = () => {
     switch (pendingAction) {
       case PendingAction.Redeem:
         daoService.redeemContributionReward(
-          networkContracts.daostack.contributionReward.redeemer,
+          networkContracts.daostack[scheme.address].redeemer,
           scheme.address,
           scheme.votingMachine,
           proposalId,


### PR DESCRIPTION
# Description

Fixes wrong access to redeem address, since the last cache update we access the schemes by address and not name in the networks contracts obj.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

# Checklist:

- [x] My code follows the existing style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any UI changes have been tested and made responsive for mobile views
