### PR TITLE
Rep consistency across history and voting

### DIFF
--- a/src/stores/DaoStore.ts
+++ b/src/stores/DaoStore.ts
@@ -675,6 +675,7 @@ export default class DaoStore {
     }[] = [];
 
     const cache = this.daoCache;
+    const totalRep = this.getRepAt().totalSupply;
 
     let proposalEvents = {
       votes: [],
@@ -741,7 +742,10 @@ export default class DaoStore {
       .concat(
         proposalEvents.votes.map(event => {
           return {
-            text: `Voted with ${event.amount} REP for decision ${
+            text: `Voted with ${bnum(event.amount)
+              .times('100')
+              .div(totalRep)
+              .toFixed(4)} % REP for decision ${
               VoteDecision[event.vote]
             } on proposal ${event.proposalId}`,
             event: {

--- a/src/stores/DaoStore.ts
+++ b/src/stores/DaoStore.ts
@@ -493,16 +493,16 @@ export default class DaoStore {
     };
 
     const proposal = this.getProposal(proposalId);
-    const totalRep = this.getRepAt().totalSupply;
 
     let history = proposalEvents.votes
       .map(event => {
+        const { totalSupply } = this.getRepAt(null, event.blockNumber);
         return {
           text: [
             `Vote from `,
             `of ${bnum(event.amount)
               .times('100')
-              .div(totalRep)
+              .div(totalSupply)
               .toFixed(4)} % REP on decision ${VoteDecision[event.vote]}`,
           ],
           textParams: [event.voter],
@@ -675,7 +675,6 @@ export default class DaoStore {
     }[] = [];
 
     const cache = this.daoCache;
-    const totalRep = this.getRepAt().totalSupply;
 
     let proposalEvents = {
       votes: [],
@@ -741,10 +740,12 @@ export default class DaoStore {
     history = history
       .concat(
         proposalEvents.votes.map(event => {
+          const { totalSupply } = this.getRepAt(null, event.blockNumber);
+
           return {
             text: `Voted with ${bnum(event.amount)
               .times('100')
-              .div(totalRep)
+              .div(totalSupply)
               .toFixed(4)} % REP for decision ${
               VoteDecision[event.vote]
             } on proposal ${event.proposalId}`,


### PR DESCRIPTION
# Description
Use event block number to get totalRepSupply instead of default currentBlockNumber in history events to fix inconsistencies across components. 

Before:
![before](https://user-images.githubusercontent.com/25844967/159989163-edf60c15-0af1-4f01-92c4-588db9e4154e.png)

After:
![After](https://user-images.githubusercontent.com/25844967/159989229-59c0d388-4788-4b80-9aae-8d595dccd859.png)



Closes https://github.com/DXgovernance/dxvote/issues/586

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Example mainnet proposal: 
https://bafybeibnnv6a5fiua3qkw4jpg7n4kuol7ygct7h4k7waqzowzbkwjpcjo4.ipfs.dweb.link/#/mainnet/proposal/0x0424e607d9224e6e4d788483aaa3083d13597402240b1c7fcc4bd818730b4f6f

# Checklist:

- [x] My code follows the existing style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any UI changes have been tested and made responsive for mobile views
