### PR TITLE
feat: Add json pin endpoint

### DIFF
--- a/src/services/IPFSService.ts
+++ b/src/services/IPFSService.ts
@@ -101,7 +101,12 @@ export default class IPFSService {
     localStorage.setItem('dxvote-newProposal-hash', hash);
 
     if (pinataService.auth) {
-      const pinataPin = await pinataService.pin(hash);
+      const pinataPin = await pinataService.pin(hash, {
+        description,
+        title,
+        tags: [...tags, 'dxvote'],
+        url: '',
+      });
       console.debug('[PINATA PIN]', pinataPin.toString());
     } else {
       console.debug('[PINATA PIN] NOT AUTHENTICATED');

--- a/src/services/PinataService.ts
+++ b/src/services/PinataService.ts
@@ -43,8 +43,34 @@ export default class PinataService {
     }
   }
 
-  async pin(hashToPin: String) {
+  async pin(hashToPin: String, jsonToPin?: any) {
     const pinataApiKey = this.context.configStore.getLocalConfig().pinata;
+    if (jsonToPin) {
+      console.log('json pin');
+      console.log(
+        await axios({
+          method: 'POST',
+          url: 'https://api.pinata.cloud/pinning/pinJSONToIPFS',
+          data: {
+            pinataOptions: {
+              cidVersion: 0,
+            },
+            pinataMetadata: {
+              name: `DXdao ${this.context.configStore.getActiveChainName()} DescriptionHash ${contentHash.fromIpfs(
+                hashToPin
+              )}`,
+              keyValues: { type: 'proposal' },
+            },
+            pinataContent: jsonToPin,
+          },
+          headers: {
+            Authorization: `Bearer ${
+              pinataApiKey ? pinataApiKey : this.defaultApiKey
+            }`,
+          },
+        })
+      );
+    }
     return axios({
       method: 'POST',
       url: 'https://api.pinata.cloud/pinning/pinByHash',


### PR DESCRIPTION
# Description

Adds an additional way of pinning that directly sends the json to pinata. Seems some people still have ipfs upload issues. This should eliminate any weird discoverability issues of pinata finding the local ipfs node with the data. 

Closes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

# Checklist:

- [ ] My code follows the existing style of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any UI changes have been tested and made responsive for mobile views
