### PR TITLE
fix(cache): reset arbitrum cache to one with all past proposals

### DIFF
--- a/src/configs/arbitrum/config.json
+++ b/src/configs/arbitrum/config.json
@@ -1,7 +1,7 @@
 {
   "cache": {
     "fromBlock": 338923,
-    "ipfsHash": "QmPRu8NFKHKPAuCXc772ozZbKLpapSUtCEYFEn4xeNccNa",
+    "ipfsHash": "QmeHRw1yf7NL4d8DYhPkg5XQUXhiHqfbQScWCqKuaY8t3Z",
     "toBlock": "32228884"
   },
   "contracts": {

--- a/src/configs/default.json
+++ b/src/configs/default.json
@@ -1,7 +1,7 @@
 {
   "mainnet": "QmXCRHdV33r42smpTa5xLwdAoB24MRNEf2XtnS4XUR3eef",
   "xdai": "QmV48NYpdqB1h8k11oBJtVp9nnGZDDHsQ85Pk3fPaG5C6x",
-  "arbitrum": "QmZVcqeUjx49vKv8pqqEYZfxN86NaSViDNeadJcSg8xc6y",
+  "arbitrum": "QmRXV1y49nTpu8PEEd487VaCBLdJAYiFvSipnBsKsXygx4",
   "rinkeby": "QmPLrb3gPwVFqPGSdj8zkpaa7oYwDvQRUr5oEgsjYXdrPo",
   "arbitrumTestnet": "QmNfPd5uBrNB2uAUauAivCSSZ7QsyvLLW6uNgxbBi3kgKV"
 }


### PR DESCRIPTION
The cache was reset on https://dxgovernance.github.io/dxvote/#/cache with @rossneilson , to block 32228884 with hash QmRXV1y49nTpu8PEEd487VaCBLdJAYiFvSipnBsKsXygx4