### PR TITLE
Fix/add new contribution rewards

### DIFF
--- a/src/components/SchemesInformation.tsx
+++ b/src/components/SchemesInformation.tsx
@@ -131,7 +131,7 @@ const SchemesInformation = observer(() => {
                         votingMachineParameters.minimumDaoBounty.toString()
                       )
                     ).toFixed(2)}{' '}
-                    DXD
+                    GEN
                   </small>
                   <br />
                   <small>

--- a/src/configs/default.json
+++ b/src/configs/default.json
@@ -1,6 +1,6 @@
 {
-  "mainnet": "QmXCRHdV33r42smpTa5xLwdAoB24MRNEf2XtnS4XUR3eef",
-  "xdai": "QmV48NYpdqB1h8k11oBJtVp9nnGZDDHsQ85Pk3fPaG5C6x",
+  "mainnet": "QmZex81Myn8kN1nS7raxnCJLh1TiZvZxmYjeT24G3WqtWN",
+  "xdai": "QmZ4YK3Lu433rx4B7RqdrG8dm7KwfSWpnBf9fy2pfJdgSD",
   "arbitrum": "QmRXV1y49nTpu8PEEd487VaCBLdJAYiFvSipnBsKsXygx4",
   "rinkeby": "QmPLrb3gPwVFqPGSdj8zkpaa7oYwDvQRUr5oEgsjYXdrPo",
   "arbitrumTestnet": "QmNfPd5uBrNB2uAUauAivCSSZ7QsyvLLW6uNgxbBi3kgKV"

--- a/src/configs/mainnet/config.json
+++ b/src/configs/mainnet/config.json
@@ -8,6 +8,45 @@
     "avatar": "0x519b70055af55a007110b4ff99b0ea33071c720a",
     "controller": "0x9f828ac3baa9003e8a4e0b24bcae7b027b6740b0",
     "daostack": {
+      "0x9d2bc77ad766259721ba3c9033c417b87a3540d0": {
+        "contractToCall": "0x9f828ac3baa9003e8a4e0b24bcae7b027b6740b0",
+        "creationLogEncoding": [
+          [
+            {
+              "name": "_descriptionHash",
+              "type": "string"
+            },
+            {
+              "name": "_reputationChange",
+              "type": "int256"
+            },
+            {
+              "name": "_rewards",
+              "type": "uint256[5]"
+            },
+            {
+              "name": "_externalToken",
+              "type": "address"
+            },
+            {
+              "name": "_beneficiary",
+              "type": "address"
+            }
+          ]
+        ],
+        "name": "ContributionReward",
+        "newProposalTopics": [
+          [
+            "0xcbdcbf9aaeb1e9eff0f75d74e1c1e044bc87110164baec7d18d825b0450d97df",
+            "0x000000000000000000000000519b70055af55a007110b4ff99b0ea33071c720a"
+          ]
+        ],
+        "redeemer": "0x406bfD9cDb247432fEEA52edD218F2a4Bd238C9b",
+        "supported": true,
+        "type": "ContributionReward",
+        "voteParams": "0x399141801e9e265d79f1f1759dd67932980664ea28c2ba7e0e4dba8719e47118",
+        "votingMachine": "0x332B8C9734b4097dE50f302F7D9F273FFdB45B84"
+      },
       "0x08cC7BBa91b849156e9c44DEd51896B38400f55B": {
         "contractToCall": "0x9f828ac3baa9003e8a4e0b24bcae7b027b6740b0",
         "creationLogEncoding": [

--- a/src/configs/xdai/config.json
+++ b/src/configs/xdai/config.json
@@ -1,8 +1,8 @@
 {
   "cache": {
     "fromBlock": 13060713,
-    "ipfsHash": "QmT82ZgxjvhU3veR4tX6nMDpbf7zisCHymQg2bC6tN2Xzy",
-    "toBlock": "24720494"
+    "ipfsHash": "QmcRbPJ1H6VvjmUB34hViVUAiMRp8A7KymNxmRHemrkkVs",
+    "toBlock": "24914890"
   },
   "contracts": {
     "avatar": "0xe716EC63C5673B3a4732D22909b38d779fa47c3F",

--- a/src/configs/xdai/config.json
+++ b/src/configs/xdai/config.json
@@ -8,6 +8,45 @@
     "avatar": "0xe716EC63C5673B3a4732D22909b38d779fa47c3F",
     "controller": "0xfBEcdD3360E2A9040383980AB3863BE9d57256fd",
     "daostack": {
+      "0x0100F4B3D8A88D5729f0D4D516d436C901C2b4AF": {
+        "contractToCall": "0xfBEcdD3360E2A9040383980AB3863BE9d57256fd",
+        "creationLogEncoding": [
+          [
+            {
+              "name": "_descriptionHash",
+              "type": "string"
+            },
+            {
+              "name": "_reputationChange",
+              "type": "int256"
+            },
+            {
+              "name": "_rewards",
+              "type": "uint256[5]"
+            },
+            {
+              "name": "_externalToken",
+              "type": "address"
+            },
+            {
+              "name": "_beneficiary",
+              "type": "address"
+            }
+          ]
+        ],
+        "name": "ContributionReward",
+        "newProposalTopics": [
+          [
+            "0xcbdcbf9aaeb1e9eff0f75d74e1c1e044bc87110164baec7d18d825b0450d97df",
+            "0x000000000000000000000000e716ec63c5673b3a4732d22909b38d779fa47c3f"
+          ]
+        ],
+        "redeemer": "0xd2cc17817c0d4cfc6819510b2e5288512122d71c",
+        "supported": false,
+        "type": "ContributionReward",
+        "voteParams": "0x1e3e01f4ce01291e53f32570ab772ef6e7301d7223b00c162494e26cc16830df",
+        "votingMachine": "0xDA309aDF1c84242Bb446F7CDBa96B570E901D4CF"
+      },
       "0x016Bf002D361bf5563c76230D19B4DaB4d66Bda4": {
         "contractToCall": "0xfBEcdD3360E2A9040383980AB3863BE9d57256fd",
         "creationLogEncoding": [


### PR DESCRIPTION
# Description

Add new ContributionReward scheme into configs, this type of schemes was not designed to be detected automatically since it is a fork of legacy schemes, therefore it needs to be added manually to the config and we need to update the cache after adding it.
