### PR TITLE
Fix double tx proposal decoding

### DIFF
--- a/src/services/CacheService.ts
+++ b/src/services/CacheService.ts
@@ -1518,7 +1518,8 @@ export default class UtilsService {
             transactionReceipt.logs.forEach(log => {
               if (
                 log.topics[0] ===
-                '0x75b4ff136cc5de5957574c797de3334eb1c141271922b825eb071e0487ba2c5c'
+                  '0x75b4ff136cc5de5957574c797de3334eb1c141271922b825eb071e0487ba2c5c' &&
+                log.logIndex === creationEvent.logIndex - 1
               ) {
                 decodedProposer = web3.eth.abi.decodeParameters(
                   [
@@ -1531,7 +1532,8 @@ export default class UtilsService {
               }
               if (
                 !creationLogDecoded &&
-                log.topics[0] === newProposalTopic[0]
+                log.topics[0] === newProposalTopic[0] &&
+                log.logIndex === creationEvent.logIndex
               ) {
                 creationLogDecoded = web3.eth.abi.decodeParameters(
                   schemeTypeData.creationLogEncoding[i],

--- a/src/stores/ConfigStore.ts
+++ b/src/stores/ConfigStore.ts
@@ -2,7 +2,6 @@ import { makeObservable, observable, action } from 'mobx';
 import RootContext from '../contexts';
 
 import {
-  CACHE_METADATA_ENS,
   NETWORK_ASSET_SYMBOL,
   NETWORK_NAMES,
   NETWORK_DISPLAY_NAMES,
@@ -36,30 +35,15 @@ export default class ConfigStore {
   }
 
   async loadNetworkConfig() {
-    const { ensService, ipfsService } = this.context;
+    const { ipfsService } = this.context;
 
     this.networkConfig = getAppConfig()[this.getActiveChainName()];
-    const isTestingEnv = !window?.location?.href?.includes('dxvote.eth');
 
     if (this.getActiveChainName() !== 'localhost' && !this.networkConfigLoaded)
       try {
-        const metadataHash = await ensService.resolveContentHash(
-          CACHE_METADATA_ENS
-        );
-        if (!metadataHash)
-          throw new Error('Cannot resolve content metadata hash.');
+        const configContentHash =
+          getDefaultConfigHashes()[this.getActiveChainName()];
 
-        if (!isTestingEnv)
-          console.debug(
-            `[ConfigStore] Found metadata content hash from ENS: ${metadataHash}`,
-            metadataHash
-          );
-
-        const configRefs = isTestingEnv
-          ? getDefaultConfigHashes()
-          : await ipfsService.getContentFromIPFS(metadataHash);
-
-        const configContentHash = configRefs[this.getActiveChainName()];
         if (!configContentHash)
           throw new Error('Cannot resolve config metadata hash.');
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -13,8 +13,6 @@ export const DEFAULT_TOKEN_DECIMALS = 18;
 
 export const MAX_BLOCKS_PER_EVENTS_FETCH: number = 1000000;
 
-export const CACHE_METADATA_ENS = 'cache.dxvote.eth';
-
 const defaultAlchemyKey = '7i7fiiOx1b7bGmgWY_oI9twyQBCsuXKC';
 
 export const DISCOURSE_URL_ROOT = 'https://daotalk.org';


### PR DESCRIPTION
- Fix issue #943 by decoding the proposal information of the event in the transaction receipt based on the logIndex, so if there is two proposals submitted in one tx it will decode different events for each of them
- Also removes use of cache.dxvote.ens content hash for cache, it is not used anymore.